### PR TITLE
feat: add filename search with fuzzy matching and directory caching

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style: normalize whitespace (no prior formatter configured)
+50d65fd

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Runtime data
+config.json
+metadata.json
+lig_ui_state.json
+.cache/
+__pycache__/
+
+# ComfyUI Manager
+.tracking
+
+# IDE
+.history/

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -124,7 +124,7 @@ def extract_prompts(metadata):
                 if str(link[1]) == str(origin_node_id) and link[2] == origin_slot_index:
                     target_node = nodes_by_id.get(str(link[3]))
                     if not target_node: continue
-                    
+
                     node_type = target_node.get('type', '').lower()
                     prop_name = target_node.get('properties', {}).get('Node name for S&R', '').lower()
                     if any(k in node_type or k in prop_name for k in display_keywords):
@@ -136,7 +136,7 @@ def extract_prompts(metadata):
             if not any('link' in i for i in node.get('inputs', []) if i.get('type') == 'STRING'):
                 widgets = node.get('widgets_values', [])
                 return next((w for w in widgets if isinstance(w, str)), "")
-            
+
             combined_text = ""
             for inp in node.get('inputs', []):
                 if inp.get('type') == 'STRING' and 'link' in inp:
@@ -144,7 +144,7 @@ def extract_prompts(metadata):
                     if link_info:
                         combined_text += resolve_text_fallback(nodes_by_id[str(link_info[1])])
             return combined_text
-        
+
         def is_sampler(node):
             return 'Sampler' in node.get('type', '')
 
@@ -153,7 +153,7 @@ def extract_prompts(metadata):
             start_node_id = str(start_node['id'])
             if start_node_id in visited: return False
             visited.add(start_node_id)
-            
+
             if is_sampler(start_node):
                 return True
 
@@ -211,33 +211,33 @@ class LocalMediaManagerNode:
         m = hashlib.sha256()
         m.update(str(selection).encode())
         m.update(str(current_path).encode())
-        
+
         try:
             selections_list = json.loads(selection)
             input_dir = folder_paths.get_input_directory()
-            
+
             for item in selections_list:
                 path = item.get('path')
                 if path and os.path.exists(path):
                     mtime = os.path.getmtime(path)
                     m.update(str(mtime).encode())
-                    
+
                     filename = os.path.basename(path)
                     name, _ = os.path.splitext(filename)
                     mask_filename = f"{name}_mask.png"
-                    
+
                     input_mask_path = os.path.join(input_dir, mask_filename)
                     if os.path.exists(input_mask_path):
                         mask_mtime = os.path.getmtime(input_mask_path)
                         m.update(str(mask_mtime).encode())
                         m.update(str(input_mask_path).encode())
-                    
+
                     original_mask_path = os.path.join(os.path.dirname(path), mask_filename)
                     if os.path.exists(original_mask_path):
                         mask_mtime = os.path.getmtime(original_mask_path)
                         m.update(str(mask_mtime).encode())
                         m.update(str(original_mask_path).encode())
-                    
+
         except Exception:
             pass
 
@@ -265,9 +265,9 @@ class LocalMediaManagerNode:
             selections_list = json.loads(selection)
         except (json.JSONDecodeError, TypeError):
             selections_list = []
-        
+
         image_paths = [item['path'] for item in selections_list if item.get('type') == 'image' and 'path' in item]
-        
+
         final_image_tensor = torch.zeros(1, 1, 1, 3)
         info_strings = []
         valid_image_paths = []
@@ -276,7 +276,7 @@ class LocalMediaManagerNode:
         if image_paths:
             sizes = {}
             batch_has_alpha = False
-            
+
             for media_path in image_paths:
                 if os.path.exists(media_path):
                     try:
@@ -291,7 +291,7 @@ class LocalMediaManagerNode:
             if valid_image_paths:
                 dominant_size = max(sizes.items(), key=lambda x: x[1])[0]
                 target_width, target_height = dominant_size
-                
+
                 target_mode = "RGBA" if batch_has_alpha else "RGB"
                 image_tensors = []
 
@@ -299,7 +299,7 @@ class LocalMediaManagerNode:
                     try:
                         with Image.open(media_path) as img:
                             img_out = img.convert(target_mode)
-                            
+
                             if img.size[0] != target_width or img.size[1] != target_height:
                                 img_array_pre = np.array(img_out).astype(np.float32) / 255.0
                                 tensor_pre = torch.from_numpy(img_array_pre)[None,].permute(0, 3, 1, 2)
@@ -307,7 +307,7 @@ class LocalMediaManagerNode:
                                 img_array = tensor_post.permute(0, 2, 3, 1).cpu().numpy().squeeze(0)
                             else:
                                 img_array = np.array(img_out).astype(np.float32) / 255.0
-                            
+
                             image_tensor = torch.from_numpy(img_array)[None,]
                             image_tensors.append(image_tensor)
 
@@ -326,20 +326,20 @@ class LocalMediaManagerNode:
                     if final_image_tensor.shape[-1] == 4:
                         if torch.min(final_image_tensor[:, :, :, 3]) > 0.9999:
                             final_image_tensor = final_image_tensor[:, :, :, :3]
-        
+
         mask_tensor = None
         if final_image_tensor is not None and final_image_tensor.nelement() > 0:
             h, w = final_image_tensor.shape[1], final_image_tensor.shape[2]
-            
+
             if valid_image_paths and final_image_tensor.shape[0] == 1:
                 first_image_path = valid_image_paths[0]
-                
+
                 filename = os.path.basename(first_image_path)
                 name, _ = os.path.splitext(filename)
                 input_dir = folder_paths.get_input_directory()
-                
+
                 input_mask_path = os.path.join(input_dir, f"{name}_mask.png")
-                
+
                 original_dir_mask_path = os.path.join(os.path.dirname(first_image_path), f"{name}_mask.png")
 
                 mask_file_to_load = None
@@ -353,12 +353,12 @@ class LocalMediaManagerNode:
                         with Image.open(mask_file_to_load) as mask_img:
                             if mask_img.width != w or mask_img.height != h:
                                 mask_img = mask_img.resize((w, h), Image.NEAREST)
-                            
+
                             if 'A' in mask_img.getbands():
                                 mask_data = mask_img.split()[-1]
                             else:
                                 mask_data = mask_img.convert("L")
-                            
+
                             mask_np = np.array(mask_data).astype(np.float32) / 255.0
                             mask_tensor = torch.from_numpy(mask_np).unsqueeze(0)
 
@@ -373,7 +373,7 @@ class LocalMediaManagerNode:
                                 inverted_alpha = 1.0 - alpha
                                 mask_tensor = torch.from_numpy(inverted_alpha).unsqueeze(0)
                     except: pass
-            
+
             if mask_tensor is None:
                  mask_tensor = torch.zeros(final_image_tensor.shape[0], h, w, dtype=torch.float32)
 
@@ -411,7 +411,7 @@ class LocalMediaManagerNode:
             except Exception as e:
                 print(f"LMM: Could not parse workflow info, falling back to default. Error: {e}")
                 pass
-        
+
         full_selection_json_string = json.dumps(enriched_selection_list, ensure_ascii=False)
 
         single_path_out = ""
@@ -463,7 +463,7 @@ def target_size(width, height, custom_width, custom_height):
     else:
         width = custom_width
         height = custom_height
-    
+
     downscale_ratio = 8
     width = int(width / downscale_ratio + 0.5) * downscale_ratio
     height = int(height / downscale_ratio + 0.5) * downscale_ratio
@@ -475,7 +475,7 @@ def get_audio(file_path, start_time=0, duration=0):
         args += ["-ss", str(start_time)]
     if duration > 0:
         args += ["-t", str(duration)]
-    
+
     args += ["-f", "f32le", "-acodec", "pcm_f32le", "-ar", "44100", "-ac", "2", "-"]
 
     try:
@@ -496,7 +496,7 @@ def get_audio(file_path, start_time=0, duration=0):
 
         waveform = torch.from_numpy(np.frombuffer(proc.stdout, dtype=np.float32))
         waveform = waveform.reshape(-1, channels).permute(1, 0)
-        
+
         return {'waveform': waveform.unsqueeze(0), 'sample_rate': sample_rate}
 
     except subprocess.CalledProcessError as e:
@@ -554,11 +554,11 @@ def cv_frame_generator(video_path, force_rate, frame_load_cap, skip_first_frames
             continue
 
         yield cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        
+
         frames_yielded += 1
         if frame_load_cap > 0 and frames_yielded >= frame_load_cap:
             break
-            
+
     video_cap.release()
 
 class SelectOriginalImageNode:
@@ -582,7 +582,7 @@ class SelectOriginalImageNode:
 
     def get_original_image(self, paths, index, frame_load_cap, generation_width, generation_height, aspect_ratio_preservation):
         selected_item = parse_selection_and_get_item(paths, index, "image")
-        
+
         empty_return = (torch.zeros(1, 1, 1, 3), 0, 0, "", "")
 
         if not selected_item or 'path' not in selected_item or not os.path.exists(selected_item['path']):
@@ -593,7 +593,7 @@ class SelectOriginalImageNode:
         try:
             with Image.open(selected_path) as img:
                 H_orig, W_orig = img.height, img.width
-                
+
                 img_out = img.convert("RGBA") if 'A' in img.getbands() else img.convert("RGB")
                 img_array = np.array(img_out).astype(np.float32) / 255.0
                 image_tensor = torch.from_numpy(img_array)[None,]
@@ -608,18 +608,18 @@ class SelectOriginalImageNode:
                         aspect_ratio = generation_height / generation_width if generation_width > 0 else 1.0
                         if aspect_ratio_preservation == "crop_to_new":
                             crop = "center"
-                    
+
                     lat_h = round(np.sqrt(max_area * aspect_ratio) / VAE_STRIDE[1] / PATCH_SIZE[1]) * PATCH_SIZE[1]
                     lat_w = round(np.sqrt(max_area / aspect_ratio) / VAE_STRIDE[2] / PATCH_SIZE[2]) * PATCH_SIZE[2]
                     h_new = int(lat_h * VAE_STRIDE[1])
                     w_new = int(lat_w * VAE_STRIDE[2])
-                    
+
                     processed_image = common_upscale(image_tensor.movedim(-1, 1), w_new, h_new, "lanczos", crop).movedim(1, -1)
                 else:
                     w_new = W_orig
                     h_new = H_orig
                     processed_image = image_tensor
-                
+
                 if frame_load_cap > 1:
                     image_sequence = processed_image.repeat(frame_load_cap, 1, 1, 1)
                 else:
@@ -627,7 +627,7 @@ class SelectOriginalImageNode:
 
                 metadata = selected_item.get('metadata', {})
                 positive_prompt, negative_prompt = extract_prompts(metadata)
-                
+
                 return (image_sequence, w_new, h_new, positive_prompt, negative_prompt,)
         except Exception as e:
             print(f"LMM Selector: Error loading or processing image {selected_path}: {e}")
@@ -663,7 +663,7 @@ class SelectOriginalVideoNode:
 
         if not selected_item or 'path' not in selected_item or not os.path.exists(selected_item['path']):
             return empty_return
-        
+
         selected_path = selected_item['path']
 
         audio_fps_estimate = force_rate if force_rate > 0 else 30
@@ -671,7 +671,7 @@ class SelectOriginalVideoNode:
         try:
             frame_generator = cv_frame_generator(selected_path, force_rate, frame_load_cap, skip_first_frames, select_every_nth)
             source_info = next(frame_generator)
-            
+
             H_orig = source_info.get("height", 0)
             W_orig = source_info.get("width", 0)
             video_fps = source_info.get("fps", 0.0)
@@ -687,7 +687,7 @@ class SelectOriginalVideoNode:
                     aspect_ratio = generation_height / generation_width if generation_width > 0 else 1.0
                     if aspect_ratio_preservation == "crop_to_new":
                         crop = "center"
-                
+
                 lat_h = round(np.sqrt(max_area * aspect_ratio) / VAE_STRIDE[1] / PATCH_SIZE[1]) * PATCH_SIZE[1]
                 lat_w = round(np.sqrt(max_area / aspect_ratio) / VAE_STRIDE[2] / PATCH_SIZE[2]) * PATCH_SIZE[2]
                 output_h = int(lat_h * VAE_STRIDE[1])
@@ -699,20 +699,20 @@ class SelectOriginalVideoNode:
 
             output_fps = force_rate if force_rate > 0 else video_fps
             frames = list(frame_generator)
-            
-            if not frames: 
+
+            if not frames:
                 return (torch.zeros(1, 1, 1, 3), 0, output_w, output_h, output_fps, audio_data, json.dumps(source_info))
 
             processed_frames = []
             for frame in frames:
                 tensor_frame = torch.from_numpy(frame).float() / 255.0
                 tensor_frame = tensor_frame.unsqueeze(0)
-                
+
                 if should_resize:
                     resized_frame = common_upscale(tensor_frame.movedim(-1, 1), output_w, output_h, "lanczos", crop).movedim(1, -1)
                 else:
                     resized_frame = tensor_frame
-                
+
                 processed_frames.append(resized_frame.squeeze(0))
 
             final_tensor = torch.stack(processed_frames)
@@ -720,7 +720,7 @@ class SelectOriginalVideoNode:
         except Exception as e:
             print(f"LMM Selector: Error loading or resizing video frames from {selected_path}: {e}")
             return empty_return
-        
+
 class SelectOriginalAudioNode:
     @classmethod
     def INPUT_TYPES(cls):
@@ -743,7 +743,7 @@ class SelectOriginalAudioNode:
 
         if not selected_item or 'path' not in selected_item:
             return (None, 0.0)
-            
+
         selected_path = selected_item['path']
 
         audio_data = get_audio(selected_path, start_time=seek_seconds, duration=duration)
@@ -754,7 +754,7 @@ class SelectOriginalAudioNode:
             loaded_duration = waveform.shape[-1] / sample_rate
             return (audio_data, loaded_duration)
         else:
-            return (None, 0.0)  
+            return (None, 0.0)
 
 prompt_server = server.PromptServer.instance
 
@@ -765,15 +765,15 @@ async def update_metadata(request):
         path = validate_path(data.get("path", ""))
         rating, tags = data.get("rating"), data.get("tags")
         if not path: return web.json_response({"status": "error", "message": "Invalid path."}, status=400)
-        
+
         metadata = load_metadata()
 
-        if path not in metadata: 
+        if path not in metadata:
             metadata[path] = {}
 
-        if rating is not None: 
+        if rating is not None:
             metadata[path]['rating'] = int(rating)
-        if tags is not None: 
+        if tags is not None:
             metadata[path]['tags'] = [str(tag).strip() for tag in tags if str(tag).strip()]
 
         entry = metadata.get(path, {})
@@ -785,7 +785,7 @@ async def update_metadata(request):
 
         save_metadata(metadata)
         return web.json_response({"status": "ok", "message": "Metadata updated"})
-    except Exception as e: 
+    except Exception as e:
         return web.json_response({"status": "error", "message": str(e)}, status=500)
 
 @prompt_server.routes.get("/local_image_gallery/get_saved_paths")
@@ -815,7 +815,7 @@ async def get_all_tags(request):
             if isinstance(tags, list):
                 for tag in tags:
                     all_tags.add(tag)
-        
+
         sorted_tags = sorted(list(all_tags), key=lambda s: s.lower())
         return web.json_response({"tags": sorted_tags})
     except Exception as e:
@@ -824,7 +824,7 @@ async def get_all_tags(request):
 def get_cached_directory_data(directory, force_refresh=False):
     now = time.time()
     cache_key = directory
-    
+
     if not force_refresh and cache_key in DIRECTORY_CACHE:
         cached_data, timestamp = DIRECTORY_CACHE[cache_key]
         if now - timestamp < CACHE_LIFETIME:
@@ -836,7 +836,7 @@ def get_cached_directory_data(directory, force_refresh=False):
     def video_has_workflow(filepath):
         try:
             with open(filepath, 'rb') as f:
-                chunk = f.read(4 * 1024 * 1024) 
+                chunk = f.read(4 * 1024 * 1024)
                 return b'"workflow":' in chunk or b'"prompt":' in chunk
         except Exception:
             return False
@@ -851,10 +851,10 @@ def get_cached_directory_data(directory, force_refresh=False):
             stats = os.stat(raw_full_path)
             item_meta = metadata.get(full_path, {})
             item_data = {
-                'path': full_path, 
-                'name': item, 
-                'mtime': stats.st_mtime, 
-                'rating': item_meta.get('rating', 0), 
+                'path': full_path,
+                'name': item,
+                'mtime': stats.st_mtime,
+                'rating': item_meta.get('rating', 0),
                 'tags': item_meta.get('tags', [])
             }
             if os.path.isdir(full_path):
@@ -915,7 +915,7 @@ async def get_local_images(request):
                 return all(ft in lower_item_tags for ft in filter_tags)
             else:
                 return any(ft in lower_item_tags for ft in filter_tags)
-        
+
         if search_mode == 'global' and filter_tags:
             metadata = load_metadata()
             for path, meta in metadata.items():
@@ -953,9 +953,9 @@ async def get_local_images(request):
             for item in directory_items:
                 if not check_tags(item.get('tags', [])):
                     continue
-                
+
                 item_type = item['type']
-                if (item_type == 'dir' or 
+                if (item_type == 'dir' or
                     (show_images and item_type == 'image') or
                     (show_videos and item_type == 'video') or
                     (show_audio and item_type == 'audio')):
@@ -970,19 +970,19 @@ async def get_local_images(request):
                     pinned_items_dict[path] = item
                 else:
                     remaining_items.append(item)
-            
+
             pinned_items = []
             for path in selected_paths:
                 if pinned_items_dict[path]:
                     pinned_items.append(pinned_items_dict[path])
-            
+
             all_items_with_meta = remaining_items
 
         reverse_order = sort_order == 'desc'
         if sort_by == 'date': all_items_with_meta.sort(key=lambda x: x['mtime'], reverse=reverse_order)
         elif sort_by == 'rating': all_items_with_meta.sort(key=lambda x: x.get('rating', 0), reverse=reverse_order)
         else: all_items_with_meta.sort(key=lambda x: x['name'].lower(), reverse=reverse_order)
-        
+
         if search_mode != 'global':
             all_items_with_meta.sort(key=lambda x: x['type'] != 'dir')
 
@@ -995,13 +995,13 @@ async def get_local_images(request):
         start = (page - 1) * per_page
         end = start + per_page
         paginated_items = all_items_with_meta[start:end]
-        
+
         return web.json_response({
             "items": paginated_items, "total_pages": (len(all_items_with_meta) + per_page - 1) // per_page,
             "current_page": page, "current_directory": directory, "parent_directory": parent_directory,
             "is_global_search": search_mode == 'global' and filter_tags
         })
-    except Exception as e: 
+    except Exception as e:
         print(f"LMM Error: {e}")
         return web.json_response({"error": str(e)}, status=500)
 
@@ -1042,11 +1042,11 @@ async def get_selected_items(request):
                     item_meta = metadata.get(path, {})
 
                     item_info = {
-                        'path': path, 
-                        'name': os.path.basename(path), 
+                        'path': path,
+                        'name': os.path.basename(path),
                         'type': item_data.get("type"),
-                        'mtime': stats.st_mtime, 
-                        'rating': item_meta.get('rating', 0), 
+                        'mtime': stats.st_mtime,
+                        'rating': item_meta.get('rating', 0),
                         'tags': item_meta.get('tags', [])
                     }
                     if item_data.get("type") == 'image':
@@ -1068,7 +1068,7 @@ async def get_selected_items(request):
             "current_page": 1,
             "current_directory": "Selected Items",
             "parent_directory": None,
-            "is_global_search": False 
+            "is_global_search": False
         })
     except Exception as e:
         return web.json_response({"error": str(e)}, status=500)
@@ -1116,7 +1116,7 @@ async def get_thumbnail(request):
 
     ext = os.path.splitext(filepath)[1].lower()
     is_video = ext in SUPPORTED_VIDEO_EXTENSIONS
-    
+
     cache_path = get_thumbnail_cache_path(filepath, is_video)
 
     if os.path.exists(cache_path) and os.path.getmtime(cache_path) > os.path.getmtime(filepath):
@@ -1166,7 +1166,7 @@ async def delete_files(request):
 
         metadata = load_metadata()
         metadata_changed = False
-        
+
         DIRECTORY_CACHE.clear()
 
         for filepath in filepaths:
@@ -1181,7 +1181,7 @@ async def delete_files(request):
                 cache_path = get_thumbnail_cache_path(filepath, is_video)
                 if os.path.exists(cache_path):
                     os.remove(cache_path)
-                
+
                 send2trash(os.path.normpath(filepath))
 
                 if filepath in metadata:
@@ -1189,7 +1189,7 @@ async def delete_files(request):
                     metadata_changed = True
             except Exception as e:
                 print(f"LMM: Error sending file to trash {os.path.normpath(filepath)}: {e}")
-        
+
         if metadata_changed:
             save_metadata(metadata)
 
@@ -1263,7 +1263,7 @@ async def move_files(request):
         return web.json_response({"status": "ok", "message": "Move operation completed.", "errors": errors})
     except Exception as e:
         return web.json_response({"status": "error", "message": str(e)}, status=500)
-    
+
 @prompt_server.routes.post("/local_image_gallery/rename_file")
 async def rename_file(request):
     DIRECTORY_CACHE.clear()
@@ -1305,7 +1305,7 @@ async def rename_file(request):
 
         return web.json_response({"status": "ok", "message": "File renamed successfully.", "new_path": new_path})
     except Exception as e:
-        return web.json_response({"status": "error", "message": str(e)}, status=500)    
+        return web.json_response({"status": "error", "message": str(e)}, status=500)
 
 @prompt_server.routes.post("/local_image_gallery/save_mask")
 async def save_mask(request):
@@ -1313,17 +1313,17 @@ async def save_mask(request):
         data = await request.json()
         image_path = data.get("image_path")
         mask_data_base64 = data.get("mask_data")
-        
+
         if not image_path or not mask_data_base64:
             return web.json_response({"status": "error", "message": "Missing parameters"}, status=400)
 
         filename = os.path.basename(image_path)
         name, _ = os.path.splitext(filename)
         input_dir = folder_paths.get_input_directory()
-        
+
         mask_filename = f"{name}_mask.png"
         mask_path = os.path.join(input_dir, mask_filename)
-        
+
         img_data = base64.b64decode(mask_data_base64.split(',')[1])
         with Image.open(io.BytesIO(img_data)) as img:
             if 'A' in img.getbands():
@@ -1338,22 +1338,22 @@ async def save_mask(request):
                     print(f"LMM: Empty mask detected, deleted {mask_filename}")
                 else:
                     print(f"LMM: Empty mask detected, nothing to save.")
-                
+
                 return web.json_response({"status": "ok", "message": "Empty mask, file cleared"})
-            
+
             mask_img.save(mask_path, "PNG")
-            
+
         return web.json_response({"status": "ok", "mask_path": mask_path})
     except Exception as e:
         print(f"LMM Error saving mask: {e}")
         return web.json_response({"status": "error", "message": str(e)}, status=500)
-    
+
 @prompt_server.routes.post("/local_image_gallery/delete_mask")
 async def delete_mask(request):
     try:
         data = await request.json()
         image_path = data.get("image_path")
-        
+
         if not image_path:
             return web.json_response({"status": "error", "message": "Missing image_path"}, status=400)
 
@@ -1361,14 +1361,14 @@ async def delete_mask(request):
         name, _ = os.path.splitext(filename)
         input_dir = folder_paths.get_input_directory()
         mask_filename = f"{name}_mask.png"
-        
+
         deleted = False
-        
+
         input_mask_path = os.path.join(input_dir, mask_filename)
         if os.path.exists(input_mask_path):
             os.remove(input_mask_path)
             deleted = True
-            
+
         original_dir_mask_path = os.path.join(os.path.dirname(image_path), mask_filename)
         if os.path.exists(original_dir_mask_path):
             os.remove(original_dir_mask_path)
@@ -1378,7 +1378,7 @@ async def delete_mask(request):
             return web.json_response({"status": "ok", "message": "Mask deleted"})
         else:
             return web.json_response({"status": "ok", "message": "No mask found to delete"})
-            
+
     except Exception as e:
         return web.json_response({"status": "error", "message": str(e)}, status=500)
 
@@ -1387,24 +1387,24 @@ async def get_mask_path(request):
     try:
         data = await request.json()
         image_path = data.get("image_path")
-        
+
         if not image_path:
             return web.json_response({"status": "error", "message": "Missing image_path"}, status=400)
 
         filename = os.path.basename(image_path)
         name, _ = os.path.splitext(filename)
         input_dir = folder_paths.get_input_directory()
-        
+
         input_mask_path = os.path.join(input_dir, f"{name}_mask.png")
         if os.path.exists(input_mask_path):
              return web.json_response({"status": "ok", "mask_path": input_mask_path})
-             
+
         original_dir_mask_path = os.path.join(os.path.dirname(image_path), f"{name}_mask.png")
         if os.path.exists(original_dir_mask_path):
              return web.json_response({"status": "ok", "mask_path": original_dir_mask_path})
 
         return web.json_response({"status": "ok", "mask_path": None})
-        
+
     except Exception as e:
         return web.json_response({"status": "error", "message": str(e)}, status=500)
 

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -22,6 +22,17 @@ import folder_paths
 VAE_STRIDE = (4, 8, 8)
 PATCH_SIZE = (1, 2, 2)
 
+def validate_path(path):
+    """Validate a file path, blocking directory traversal.
+    Accepts both relative and absolute paths.
+    Returns the normalized path, or None if the path is invalid/unsafe."""
+    if not path:
+        return None
+    path = path.replace("\\", "/")
+    if ".." in path.split("/"):
+        return None
+    return os.path.normpath(path)
+
 NODE_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE = os.path.join(NODE_DIR, "config.json")
 METADATA_FILE = os.path.join(NODE_DIR, "metadata.json")
@@ -751,9 +762,9 @@ prompt_server = server.PromptServer.instance
 async def update_metadata(request):
     try:
         data = await request.json()
-        path = data.get("path", "").replace("\\", "/")
+        path = validate_path(data.get("path", ""))
         rating, tags = data.get("rating"), data.get("tags")
-        if not path or not os.path.isabs(path): return web.json_response({"status": "error", "message": "Invalid path."}, status=400)
+        if not path: return web.json_response({"status": "error", "message": "Invalid path."}, status=400)
         
         metadata = load_metadata()
 
@@ -1099,12 +1110,10 @@ def get_thumbnail_cache_path(filepath, is_video=False):
 
 @prompt_server.routes.get("/local_image_gallery/thumbnail")
 async def get_thumbnail(request):
-    filepath = request.query.get('filepath')
-    if not filepath or ".." in filepath: return web.Response(status=400)
-
-    filepath = urllib.parse.unquote(filepath)
+    filepath = validate_path(urllib.parse.unquote(request.query.get('filepath', '')))
+    if not filepath: return web.Response(status=400)
     if not os.path.exists(filepath): return web.Response(status=404)
-    
+
     ext = os.path.splitext(filepath)[1].lower()
     is_video = ext in SUPPORTED_VIDEO_EXTENSIONS
     
@@ -1141,9 +1150,8 @@ async def get_thumbnail(request):
 
 @prompt_server.routes.get("/local_image_gallery/view")
 async def view_image(request):
-    filepath = request.query.get('filepath')
-    if not filepath or ".." in filepath: return web.Response(status=400)
-    filepath = urllib.parse.unquote(filepath)
+    filepath = validate_path(urllib.parse.unquote(request.query.get('filepath', '')))
+    if not filepath: return web.Response(status=400)
     if not os.path.exists(filepath): return web.Response(status=404)
     try: return web.FileResponse(filepath)
     except: return web.Response(status=500)
@@ -1162,7 +1170,8 @@ async def delete_files(request):
         DIRECTORY_CACHE.clear()
 
         for filepath in filepaths:
-            if not filepath or not os.path.isabs(filepath) or ".." in filepath:
+            filepath = validate_path(filepath)
+            if not filepath:
                 continue
             if not os.path.isfile(filepath):
                 continue
@@ -1199,9 +1208,9 @@ async def move_files(request):
         if not isinstance(source_paths, list) or not destination_dir:
             return web.json_response({"status": "error", "message": "Invalid data format."}, status=400)
 
-        normalized_destination_dir = os.path.normpath(destination_dir)
+        normalized_destination_dir = validate_path(destination_dir)
 
-        if not os.path.isabs(normalized_destination_dir) or not os.path.isdir(normalized_destination_dir):
+        if not normalized_destination_dir or not os.path.isdir(normalized_destination_dir):
             return web.json_response({"status": "error", "message": "Invalid or unsafe destination directory."}, status=400)
 
         metadata = load_metadata()
@@ -1210,9 +1219,9 @@ async def move_files(request):
 
         for original_source_path in source_paths:
             try:
-                normalized_source_path = os.path.normpath(original_source_path)
+                normalized_source_path = validate_path(original_source_path)
 
-                if not normalized_source_path or not os.path.isabs(normalized_source_path) or not os.path.isfile(normalized_source_path):
+                if not normalized_source_path or not os.path.isfile(normalized_source_path):
                     continue
 
                 source_dir = os.path.dirname(normalized_source_path)
@@ -1263,7 +1272,8 @@ async def rename_file(request):
         old_path = data.get("old_path")
         new_name = data.get("new_name")
 
-        if not old_path or not os.path.isabs(old_path) or not os.path.isfile(old_path):
+        old_path = validate_path(old_path)
+        if not old_path or not os.path.isfile(old_path):
             return web.json_response({"status": "error", "message": "Invalid or non-existent source file."}, status=400)
 
         if not new_name or "/" in new_name or "\\" in new_name:

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -955,7 +955,18 @@ def _check_has_workflow(filepath, mtime, item_type):
 def _build_item(full_path, fname, stats, item_type, meta=None, metadata_store=None):
     """Build a media item dict. Provide either meta= directly or metadata_store= to look up by path."""
     if meta is None:
-        meta = (metadata_store or {}).get(full_path, {})
+        if metadata_store:
+            meta = metadata_store.get(full_path, None)
+            if meta is None:
+                # Absolute paths from search won't match relative keys in metadata.
+                comfy_dir = os.path.dirname(os.path.dirname(NODE_DIR))
+                comfy_prefix = comfy_dir.rstrip("/") + "/"
+                if full_path.startswith(comfy_prefix):
+                    meta = metadata_store.get(full_path[len(comfy_prefix):], None)
+            if meta is None:
+                meta = {}
+        else:
+            meta = {}
     item = {
         'path': full_path,
         'name': fname,

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -23,6 +23,18 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+try:
+    import av as _av
+    _AV_AVAILABLE = True
+except ImportError:
+    _av = None
+    _AV_AVAILABLE = False
+    logger.warning(
+        "ComfyUI_Local_Media_Manager: PyAV (`av`) not installed — falling back to "
+        "OpenCV. OpenCV cannot decode AV1 (and some other modern codecs). "
+        "Install `av` for full codec support: pip install av"
+    )
+
 VAE_STRIDE = (4, 8, 8)
 PATCH_SIZE = (1, 2, 2)
 
@@ -703,23 +715,19 @@ def get_audio(file_path, start_time=0, duration=0):
         print(f"LMM Selector: An unexpected error occurred during audio extraction: {e}")
         return {'waveform': torch.zeros(1, 2, 1), 'sample_rate': 44100}
 
-def cv_frame_generator(video_path, force_rate, frame_load_cap, skip_first_frames, select_every_nth):
+def _cv_frame_generator_cv2(video_path, force_rate, frame_load_cap, skip_first_frames, select_every_nth, fps, width, height, total_frames):
+    """Yield video frames via cv2.VideoCapture.
+
+    Expects the metadata dict to have already been yielded by the caller.
+    """
     video_cap = cv2.VideoCapture(video_path)
     if not video_cap.isOpened():
         raise IOError(f"Cannot open video file: {video_path}")
 
-    fps = video_cap.get(cv2.CAP_PROP_FPS)
-    width = int(video_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(video_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    total_frames = int(video_cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    duration = total_frames / fps if fps > 0 else 0
-
-    yield {"width": width, "height": height, "fps": fps, "total_frames": total_frames, "duration": duration}
-
     base_frame_time = 1.0 / fps if fps > 0 else 0
     target_frame_time = 1.0 / force_rate if force_rate > 0 else base_frame_time
     if target_frame_time <= 0:
-        target_frame_time = base_frame_time if base_frame_time > 0 else 1.0/30.0
+        target_frame_time = base_frame_time if base_frame_time > 0 else 1.0 / 30.0
 
     video_cap.set(cv2.CAP_PROP_POS_FRAMES, skip_first_frames)
 
@@ -727,36 +735,130 @@ def cv_frame_generator(video_path, force_rate, frame_load_cap, skip_first_frames
     frames_yielded = 0
     total_frames_evaluated = -1
 
-    while video_cap.isOpened():
-        current_pos_frames = skip_first_frames + frames_yielded
-        if total_frames > 0 and current_pos_frames >= total_frames:
-            break
+    try:
+        while video_cap.isOpened():
+            current_pos_frames = skip_first_frames + frames_yielded
+            if total_frames > 0 and current_pos_frames >= total_frames:
+                break
 
-        if force_rate > 0:
-            while time_offset < target_frame_time:
-                if not video_cap.grab():
-                    video_cap.release()
-                    return
+            if force_rate > 0:
+                while time_offset < target_frame_time:
+                    if not video_cap.grab():
+                        return
+                    time_offset += base_frame_time
+                time_offset -= target_frame_time
+                ret, frame = video_cap.retrieve()
+            else:
+                ret, frame = video_cap.read()
+
+            if not ret:
+                break
+
+            total_frames_evaluated += 1
+            if total_frames_evaluated % select_every_nth != 0:
+                continue
+
+            yield cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+            frames_yielded += 1
+            if frame_load_cap > 0 and frames_yielded >= frame_load_cap:
+                break
+    finally:
+        video_cap.release()
+
+
+def _cv_frame_generator_av(video_path, force_rate, frame_load_cap, skip_first_frames, select_every_nth, fps, total_frames):
+    """Yield video frames via PyAV (primary backend).
+
+    Expects the metadata dict to have already been yielded by the caller.
+    Streams frames one at a time (O(1) memory) — never accumulates a list.
+    Applies skip_first_frames, select_every_nth, frame_load_cap, and
+    force_rate with the same semantics as the cv2 fallback.
+    """
+    container = None
+    try:
+        container = _av.open(video_path)
+        video_stream = container.streams.video[0]
+        video_stream.thread_type = "AUTO"
+
+        base_frame_time = 1.0 / fps if fps > 0 else 0.0
+        target_frame_time = 1.0 / force_rate if force_rate > 0 else base_frame_time
+        if target_frame_time <= 0:
+            target_frame_time = base_frame_time if base_frame_time > 0 else 1.0 / 30.0
+
+        frames_decoded = 0      # total decoded frames (includes skipped ones)
+        frames_yielded = 0
+        total_frames_evaluated = -1
+        time_offset = target_frame_time  # start ready to yield the first frame
+
+        for av_frame in container.decode(video=0):
+            if total_frames > 0 and frames_decoded >= total_frames:
+                break
+
+            frames_decoded += 1
+
+            # skip_first_frames: discard leading frames without evaluating them
+            if frames_decoded <= skip_first_frames:
+                continue
+
+            # force_rate: accumulate base-rate frames until the next target tick
+            if force_rate > 0:
                 time_offset += base_frame_time
-            time_offset -= target_frame_time
-            ret, frame = video_cap.retrieve()
-        else:
-             ret, frame = video_cap.read()
+                if time_offset < target_frame_time:
+                    continue
+                time_offset -= target_frame_time
 
-        if not ret:
-            break
+            total_frames_evaluated += 1
+            if total_frames_evaluated % select_every_nth != 0:
+                continue
 
-        total_frames_evaluated += 1
-        if total_frames_evaluated % select_every_nth != 0:
-            continue
+            yield av_frame.to_ndarray(format="rgb24")
 
-        yield cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            frames_yielded += 1
+            if frame_load_cap > 0 and frames_yielded >= frame_load_cap:
+                break
+    finally:
+        if container is not None:
+            container.close()
 
-        frames_yielded += 1
-        if frame_load_cap > 0 and frames_yielded >= frame_load_cap:
-            break
 
-    video_cap.release()
+def cv_frame_generator(video_path, force_rate, frame_load_cap, skip_first_frames, select_every_nth):
+    """Generate video frames, yielding a metadata dict first then RGB uint8 ndarrays.
+
+    Uses PyAV as the primary backend (handles AV1 and all codecs that the
+    system libavcodec supports). Falls back to cv2.VideoCapture only when
+    PyAV is not installed.
+    """
+    meta = _ffprobe_video_metadata(video_path)
+    if meta is None:
+        raise IOError(f"Cannot read video metadata: {video_path}")
+
+    fps = meta.get("fps", 0.0)
+    width = meta.get("width", 0)
+    height = meta.get("height", 0)
+    total_frames = meta.get("total_frames", 0)
+    duration = meta.get("duration", total_frames / fps if fps > 0 else 0)
+
+    yield {"width": width, "height": height, "fps": fps, "total_frames": total_frames, "duration": duration}
+
+    if _AV_AVAILABLE:
+        yield from _cv_frame_generator_av(
+            video_path, force_rate, frame_load_cap, skip_first_frames,
+            select_every_nth, fps, total_frames,
+        )
+        return
+
+    try:
+        yield from _cv_frame_generator_cv2(
+            video_path, force_rate, frame_load_cap, skip_first_frames,
+            select_every_nth, fps, width, height, total_frames,
+        )
+    except Exception:
+        logger.error(
+            "OpenCV could not decode %s — likely an AV1/unsupported codec. "
+            "Install `av` (pip install av) for full codec support.", video_path,
+        )
+        raise
 
 class SelectOriginalImageNode:
     @classmethod
@@ -1071,27 +1173,94 @@ def _check_has_workflow(filepath, mtime, item_type):
         return has_wf
     return None
 
+def _ffprobe_video_metadata_av(full_path):
+    """Read video metadata via PyAV (primary backend)."""
+    container = None
+    try:
+        container = _av.open(full_path)
+        vs = container.streams.video[0]
+
+        info = {
+            'width': vs.width,
+            'height': vs.height,
+        }
+
+        # average_rate is the most reliable fps source; fall back to guessed_rate
+        rate = vs.average_rate or vs.guessed_rate
+        fps = float(rate) if rate else 0.0
+
+        if fps > 0:
+            info['fps'] = round(fps, 2)
+
+            # vs.frames may be 0 for some containers (e.g. mkv without index)
+            total = vs.frames or 0
+
+            # Container duration is in AV_TIME_BASE units (microseconds)
+            duration = 0.0
+            if container.duration is not None:
+                duration = float(container.duration) / 1_000_000.0
+            elif vs.duration is not None and vs.time_base is not None:
+                duration = float(vs.duration * vs.time_base)
+
+            if total > 0:
+                info['total_frames'] = total
+                info['duration'] = round(total / fps, 2)
+            elif duration > 0:
+                info['duration'] = round(duration, 2)
+                info['total_frames'] = int(round(duration * fps))
+
+        return info
+    except Exception as exc:
+        logger.warning("PyAV metadata read failed for %s: %s", full_path, exc)
+        return None
+    finally:
+        if container is not None:
+            container.close()
+
+
+def _ffprobe_video_metadata_cv2(full_path):
+    """Read video metadata via cv2.VideoCapture (fallback when ffprobe is absent)."""
+    cap = cv2.VideoCapture(full_path)
+    if not cap.isOpened():
+        return None
+    try:
+        w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        info = {'width': w, 'height': h}
+        if fps and fps > 0:
+            info['fps'] = round(fps, 2)
+            if total > 0:
+                info['total_frames'] = total
+                info['duration'] = round(total / fps, 2)
+        return info
+    finally:
+        cap.release()
+
+
+def _ffprobe_video_metadata(full_path):
+    """Read video dimensions/fps/duration.
+
+    Tries PyAV first (handles AV1 and all codecs the system libavcodec supports).
+    Falls back to cv2.VideoCapture when PyAV is not installed.
+    """
+    if _AV_AVAILABLE:
+        return _ffprobe_video_metadata_av(full_path)
+    result = _ffprobe_video_metadata_cv2(full_path)
+    if result is None:
+        logger.error(
+            "OpenCV could not read metadata for %s — likely an AV1/unsupported "
+            "codec. Install `av` (pip install av) for full codec support.", full_path,
+        )
+    return result
+
+
 def _get_media_info(full_path, item_type):
     """Extract media metadata (dimensions, fps, duration) without decoding frames."""
     try:
         if item_type == 'video':
-            cap = cv2.VideoCapture(full_path)
-            if not cap.isOpened():
-                return None
-            try:
-                w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-                h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-                fps = cap.get(cv2.CAP_PROP_FPS)
-                total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                info = {'width': w, 'height': h}
-                if fps and fps > 0:
-                    info['fps'] = round(fps, 2)
-                    if total > 0:
-                        info['total_frames'] = total
-                        info['duration'] = round(total / fps, 2)
-                return info
-            finally:
-                cap.release()
+            return _ffprobe_video_metadata(full_path)
         elif item_type == 'image':
             with Image.open(full_path) as img:
                 w, h = img.size
@@ -1677,6 +1846,51 @@ def get_thumbnail_cache_path(filepath, is_video=False):
     filename = hashlib.md5(filepath.encode('utf-8')).hexdigest()
     return os.path.join(THUMBNAIL_CACHE_DIR, filename + ".webp")
 
+def _extract_video_frame_av(filepath):
+    """Decode the first video frame as a PIL image via PyAV (primary backend)."""
+    container = None
+    try:
+        container = _av.open(filepath)
+        for av_frame in container.decode(video=0):
+            return av_frame.to_image()
+        raise ValueError("No frames decoded from video")
+    finally:
+        if container is not None:
+            container.close()
+
+
+def _extract_video_frame_cv2(filepath):
+    """Decode the first video frame as a PIL image via cv2 (fallback when ffmpeg absent)."""
+    video_cap = cv2.VideoCapture(filepath)
+    if not video_cap.isOpened():
+        raise IOError("Cannot open video file")
+    try:
+        ret, frame = video_cap.read()
+        if not ret:
+            raise ValueError("Cannot read frame from video")
+        return Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+    finally:
+        if video_cap.isOpened():
+            video_cap.release()
+
+
+def _extract_video_frame(filepath):
+    """Decode the first frame of a video as a PIL image.
+
+    Tries PyAV first (handles AV1 and all codecs the system libavcodec supports).
+    Falls back to cv2.VideoCapture when PyAV is not installed.
+    """
+    if _AV_AVAILABLE:
+        return _extract_video_frame_av(filepath)
+    try:
+        return _extract_video_frame_cv2(filepath)
+    except Exception:
+        logger.error(
+            "OpenCV could not decode %s — likely an AV1/unsupported codec. "
+            "Install `av` (pip install av) for full codec support.", filepath,
+        )
+        raise
+
 @prompt_server.routes.get("/local_image_gallery/thumbnail")
 async def get_thumbnail(request):
     filepath = validate_path(urllib.parse.unquote(request.query.get('filepath', '')))
@@ -1693,20 +1907,9 @@ async def get_thumbnail(request):
 
     try:
         if is_video:
-            try:
-                video_cap = cv2.VideoCapture(filepath)
-                if not video_cap.isOpened():
-                    raise IOError("Cannot open video file")
-                ret, frame = video_cap.read()
-                if not ret:
-                    raise ValueError("Cannot read frame from video")
-
-                img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-                img.thumbnail([320, 320], Image.LANCZOS)
-                img.save(cache_path, "WEBP", quality=80)
-            finally:
-                if 'video_cap' in locals() and video_cap.isOpened():
-                    video_cap.release()
+            img = _extract_video_frame(filepath)
+            img.thumbnail([320, 320], Image.LANCZOS)
+            img.save(cache_path, "WEBP", quality=80)
         else:
             img = Image.open(filepath)
             img = ImageOps.exif_transpose(img)

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -38,17 +38,75 @@ def validate_path(path):
     return os.path.normpath(path)
 
 NODE_DIR = os.path.dirname(os.path.abspath(__file__))
-CONFIG_FILE = os.path.join(NODE_DIR, "config.json")
-METADATA_FILE = os.path.join(NODE_DIR, "metadata.json")
-UI_STATE_FILE = os.path.join(NODE_DIR, "lig_ui_state.json")
-CACHE_DIR = os.path.join(NODE_DIR, ".cache")
-THUMBNAIL_CACHE_DIR = os.path.join(CACHE_DIR, "thumbnails")
 
 SUPPORTED_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.bmp', '.gif', '.webp']
 SUPPORTED_VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mov', '.mkv', '.avi']
 SUPPORTED_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.ogg', '.flac', '.m4a']
 
-CACHE_LIFETIME = 1800
+
+def _get_data_dir():
+    """Return the canonical data directory for this node under ComfyUI's user dir."""
+    user_dir = folder_paths.get_user_directory()
+    data_dir = os.path.join(user_dir, "default", "local_media_manager")
+    os.makedirs(data_dir, exist_ok=True)
+    return data_dir
+
+
+def _migrate_data_files():
+    """One-time migration: move data files from NODE_DIR to the proper data dir.
+
+    Moves config.json, metadata.json, lig_ui_state.json.
+    If a file already exists at the destination, skip it and log a warning
+    (never overwrite — no data loss).
+    """
+    data_dir = _get_data_dir()
+    files_to_migrate = ['config.json', 'metadata.json', 'lig_ui_state.json']
+    migrated = []
+
+    for fname in files_to_migrate:
+        src = os.path.join(NODE_DIR, fname)
+        dst = os.path.join(data_dir, fname)
+        if not os.path.exists(src):
+            continue
+        if os.path.exists(dst):
+            logger.warning(f"LMM migration: skipping {fname} — already exists at {dst}")
+            continue
+        try:
+            shutil.move(src, dst)
+            migrated.append(fname)
+        except Exception as e:
+            logger.error(f"LMM migration: failed to move {fname}: {e}")
+
+    if migrated:
+        logger.info(f"LMM migration: moved {', '.join(migrated)} to {data_dir}")
+
+
+_migrate_data_files()
+
+DATA_DIR = _get_data_dir()
+CONFIG_FILE = os.path.join(DATA_DIR, "config.json")
+METADATA_FILE = os.path.join(DATA_DIR, "metadata.json")
+UI_STATE_FILE = os.path.join(DATA_DIR, "lig_ui_state.json")
+CACHE_DIR = os.path.join(os.environ.get('XDG_CACHE_HOME', os.path.expanduser('~/.cache')), 'local_media_manager')
+THUMBNAIL_CACHE_DIR = os.path.join(CACHE_DIR, "thumbnails")
+
+
+def _resolve_cache_ttl():
+    """Cache TTL in seconds. config.json > env LMM_CACHE_TTL > default 24h."""
+    try:
+        with open(CONFIG_FILE) as f:
+            cfg = json.load(f)
+        if 'cache_ttl' in cfg:
+            return int(cfg['cache_ttl'])
+    except Exception:
+        pass
+    env = os.environ.get('LMM_CACHE_TTL')
+    if env:
+        return int(env)
+    return 86400
+
+
+CACHE_LIFETIME = _resolve_cache_ttl()
 DIRSCAN_CACHE_DIR = os.path.join(CACHE_DIR, "dirscan")
 
 
@@ -123,17 +181,35 @@ def ensure_cache_dirs():
 
 ensure_cache_dirs()
 
+CONFIG_DEFAULTS = {
+    "saved_paths": [],
+    "cache_ttl": 86400,
+}
+
 def save_config(data):
     try:
         with open(CONFIG_FILE, 'w', encoding='utf-8') as f: json.dump(data, f, indent=4)
     except Exception as e: print(f"LocalMediaManager: Error saving config: {e}")
 
 def load_config():
+    cfg = {}
     if os.path.exists(CONFIG_FILE):
         try:
-            with open(CONFIG_FILE, 'r', encoding='utf-8') as f: return json.load(f)
-        except: pass
-    return {}
+            with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+                cfg = json.load(f)
+        except Exception:
+            pass
+    changed = False
+    for key, default in CONFIG_DEFAULTS.items():
+        if key not in cfg:
+            cfg[key] = default
+            changed = True
+    if changed:
+        save_config(cfg)
+    return cfg
+
+# Seed default config keys on startup
+load_config()
 
 METADATA_CACHE = {'data': None, 'mtime': 0}
 

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -4,7 +4,7 @@ import os
 import json
 import torch
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 import urllib.parse
 import io
 from comfy.utils import common_upscale
@@ -476,6 +476,7 @@ class LocalMediaManagerNode:
                 if os.path.exists(media_path):
                     try:
                         with Image.open(media_path) as img:
+                            img = ImageOps.exif_transpose(img)
                             sizes[img.size] = sizes.get(img.size, 0) + 1
                             valid_image_paths.append(media_path)
                             if not batch_has_alpha and (img.mode == 'RGBA' or (img.mode == 'P' and 'transparency' in img.info)):
@@ -493,6 +494,7 @@ class LocalMediaManagerNode:
                 for media_path in valid_image_paths:
                     try:
                         with Image.open(media_path) as img:
+                            img = ImageOps.exif_transpose(img)
                             img_out = img.convert(target_mode)
 
                             if img.size[0] != target_width or img.size[1] != target_height:
@@ -787,6 +789,7 @@ class SelectOriginalImageNode:
 
         try:
             with Image.open(selected_path) as img:
+                img = ImageOps.exif_transpose(img)
                 H_orig, W_orig = img.height, img.width
 
                 img_out = img.convert("RGBA") if 'A' in img.getbands() else img.convert("RGB")
@@ -1706,6 +1709,7 @@ async def get_thumbnail(request):
                     video_cap.release()
         else:
             img = Image.open(filepath)
+            img = ImageOps.exif_transpose(img)
             img.thumbnail([320, 320], Image.LANCZOS)
             img.save(cache_path, "WEBP", quality=85)
 

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -952,6 +952,35 @@ def _check_has_workflow(filepath, mtime, item_type):
         return has_wf
     return None
 
+def _get_media_info(full_path, item_type):
+    """Extract media metadata (dimensions, fps, duration) without decoding frames."""
+    try:
+        if item_type == 'video':
+            cap = cv2.VideoCapture(full_path)
+            if not cap.isOpened():
+                return None
+            try:
+                w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                fps = cap.get(cv2.CAP_PROP_FPS)
+                total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                info = {'width': w, 'height': h}
+                if fps and fps > 0:
+                    info['fps'] = round(fps, 2)
+                    if total > 0:
+                        info['total_frames'] = total
+                        info['duration'] = round(total / fps, 2)
+                return info
+            finally:
+                cap.release()
+        elif item_type == 'image':
+            with Image.open(full_path) as img:
+                w, h = img.size
+            return {'width': w, 'height': h}
+    except Exception:
+        pass
+    return None
+
 def _build_item(full_path, fname, stats, item_type, meta=None, metadata_store=None):
     """Build a media item dict. Provide either meta= directly or metadata_store= to look up by path."""
     if meta is None:
@@ -978,6 +1007,10 @@ def _build_item(full_path, fname, stats, item_type, meta=None, metadata_store=No
     has_wf = _check_has_workflow(full_path, stats.st_mtime, item_type)
     if has_wf is not None:
         item['has_workflow'] = has_wf
+    if item_type in ('image', 'video'):
+        media_info = _get_media_info(full_path, item_type)
+        if media_info:
+            item['media_info'] = media_info
     return item
 
 def _scan_directory(directory):

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -286,10 +286,48 @@ def extract_prompts(metadata):
 
 class LocalMediaManagerNode:
     @classmethod
+    def _get_connected_outputs(cls, unique_id):
+        """Check which output slots are connected in the current prompt.
+
+        Inspects the running prompt via PromptServer to find downstream
+        references to this node's outputs.  Returns (image, mask) booleans.
+        Defaults to (True, True) on any failure so the hash stays conservative.
+        """
+        if unique_id is None:
+            return True, True
+        node_id = str(unique_id)
+        try:
+            from server import PromptServer
+            running = PromptServer.instance.prompt_queue.currently_running
+            prompt = None
+            for item in running.values():
+                prompt = item[2]  # (number, prompt_id, prompt, ...)
+                break
+            if not prompt:
+                return True, True
+            image_connected = False
+            mask_connected = False
+            for node_info in prompt.values():
+                for v in node_info.get("inputs", {}).values():
+                    if isinstance(v, list) and len(v) == 2 and str(v[0]) == node_id:
+                        if v[1] == 0:
+                            image_connected = True
+                        elif v[1] == 1:
+                            mask_connected = True
+            return image_connected, mask_connected
+        except Exception:
+            return True, True
+
+    @classmethod
     def IS_CHANGED(cls, selection, current_path="", **kwargs):
         m = hashlib.sha256()
         m.update(str(selection).encode())
         m.update(str(current_path).encode())
+
+        # Only invalidate on file changes for outputs that are actually wired up
+        image_connected, mask_connected = cls._get_connected_outputs(
+            kwargs.get("unique_id")
+        )
 
         try:
             selections_list = json.loads(selection)
@@ -298,24 +336,26 @@ class LocalMediaManagerNode:
             for item in selections_list:
                 path = item.get('path')
                 if path and os.path.exists(path):
-                    mtime = os.path.getmtime(path)
-                    m.update(str(mtime).encode())
+                    if image_connected:
+                        mtime = os.path.getmtime(path)
+                        m.update(str(mtime).encode())
 
-                    filename = os.path.basename(path)
-                    name, _ = os.path.splitext(filename)
-                    mask_filename = f"{name}_mask.png"
+                    if mask_connected:
+                        filename = os.path.basename(path)
+                        name, _ = os.path.splitext(filename)
+                        mask_filename = f"{name}_mask.png"
 
-                    input_mask_path = os.path.join(input_dir, mask_filename)
-                    if os.path.exists(input_mask_path):
-                        mask_mtime = os.path.getmtime(input_mask_path)
-                        m.update(str(mask_mtime).encode())
-                        m.update(str(input_mask_path).encode())
+                        input_mask_path = os.path.join(input_dir, mask_filename)
+                        if os.path.exists(input_mask_path):
+                            mask_mtime = os.path.getmtime(input_mask_path)
+                            m.update(str(mask_mtime).encode())
+                            m.update(str(input_mask_path).encode())
 
-                    original_mask_path = os.path.join(os.path.dirname(path), mask_filename)
-                    if os.path.exists(original_mask_path):
-                        mask_mtime = os.path.getmtime(original_mask_path)
-                        m.update(str(mask_mtime).encode())
-                        m.update(str(original_mask_path).encode())
+                        original_mask_path = os.path.join(os.path.dirname(path), mask_filename)
+                        if os.path.exists(original_mask_path):
+                            mask_mtime = os.path.getmtime(original_mask_path)
+                            m.update(str(mask_mtime).encode())
+                            m.update(str(original_mask_path).encode())
 
         except Exception:
             pass
@@ -981,6 +1021,19 @@ def _get_media_info(full_path, item_type):
         pass
     return None
 
+def _find_mask_path(full_path):
+    """Return the mask sidecar path if it exists (input dir first, then original dir), else None."""
+    name, _ = os.path.splitext(os.path.basename(full_path))
+    mask_filename = f"{name}_mask.png"
+    input_dir = folder_paths.get_input_directory()
+    input_mask = os.path.join(input_dir, mask_filename)
+    if os.path.exists(input_mask):
+        return input_mask
+    original_mask = os.path.join(os.path.dirname(full_path), mask_filename)
+    if os.path.exists(original_mask):
+        return original_mask
+    return None
+
 def _build_item(full_path, fname, stats, item_type, meta=None, metadata_store=None):
     """Build a media item dict. Provide either meta= directly or metadata_store= to look up by path."""
     if meta is None:
@@ -1008,6 +1061,10 @@ def _build_item(full_path, fname, stats, item_type, meta=None, metadata_store=No
     if has_wf is not None:
         item['has_workflow'] = has_wf
     if item_type in ('image', 'video'):
+        mask_path = _find_mask_path(full_path)
+        item['has_mask'] = mask_path is not None
+        if mask_path:
+            item['mask_path'] = mask_path
         media_info = _get_media_info(full_path, item_type)
         if media_info:
             item['media_info'] = media_info
@@ -1029,6 +1086,9 @@ def _scan_directory(directory):
             if os.path.isdir(full_path):
                 all_items.append(_build_item(full_path, item, stats, 'dir', metadata_store=metadata))
             else:
+                name_no_ext = os.path.splitext(item)[0]
+                if name_no_ext.endswith('_mask'):
+                    continue
                 ext = os.path.splitext(item)[1].lower()
                 item_type = _ext_to_type(ext)
                 if item_type:
@@ -1116,6 +1176,9 @@ def _search_walk(roots, query_lower, metadata, all_extensions, visited, match_fn
 
             for fname in filenames:
                 if not match_fn(query_lower, fname.lower()):
+                    continue
+                name_no_ext = os.path.splitext(fname)[0]
+                if name_no_ext.endswith('_mask'):
                     continue
                 ext = os.path.splitext(fname)[1].lower()
                 if ext not in all_extensions:
@@ -1230,6 +1293,7 @@ async def get_local_images(request):
     else:
         filter_ratings = None
     recursive = request.query.get('recursive', 'false').lower() == 'true'
+    mask_filter = request.query.get('mask_filter', '')  # 'mask_only', 'no_mask', or '' (no filter)
 
     page = int(request.query.get('page', 1))
     per_page = int(request.query.get('per_page', 50))
@@ -1253,6 +1317,16 @@ async def get_local_images(request):
             if filter_ratings is None:
                 return True
             return item_rating in filter_ratings
+
+        def check_mask(item):
+            if not mask_filter:
+                return True
+            has_mask = item.get('has_mask', False)
+            if mask_filter == 'mask_only':
+                return has_mask
+            if mask_filter == 'no_mask':
+                return not has_mask
+            return True
 
         def _type_visible(item_type):
             return (item_type == 'dir' or
@@ -1278,6 +1352,8 @@ async def get_local_images(request):
                         item = {**item, 'path': item['path'][len(comfy_prefix):]}
                     if not check_rating(item.get('rating', 0)):
                         continue
+                    if not check_mask(item):
+                        continue
                     if _type_visible(item['type']):
                         all_items_with_meta.append(item)
                         seen_paths.add(item['path'])
@@ -1301,6 +1377,8 @@ async def get_local_images(request):
                             try:
                                 stats = os.stat(path)
                                 built = _build_item(path, os.path.basename(path), stats, item_type, meta=meta)
+                                if not check_mask(built):
+                                    continue
                                 if path != norm_path:
                                     built = {**built, 'path': norm_path}
                                 all_items_with_meta.append(built)
@@ -1315,6 +1393,8 @@ async def get_local_images(request):
                     if not check_tags(item.get('tags', [])):
                         continue
                     if not check_rating(item.get('rating', 0)):
+                        continue
+                    if not check_mask(item):
                         continue
                     if _type_visible(item['type']):
                         all_items_with_meta.append(item)
@@ -1337,6 +1417,8 @@ async def get_local_images(request):
                         continue
                     if not check_rating(item.get('rating', 0)):
                         continue
+                    if not check_mask(item):
+                        continue
                     all_items_with_meta.append(item)
 
         elif search_mode == 'global' and filter_tags:
@@ -1357,7 +1439,10 @@ async def get_local_images(request):
                         if item_type:
                             try:
                                 stats = os.stat(path)
-                                all_items_with_meta.append(_build_item(path, os.path.basename(path), stats, item_type, meta=meta))
+                                built = _build_item(path, os.path.basename(path), stats, item_type, meta=meta)
+                                if not check_mask(built):
+                                    continue
+                                all_items_with_meta.append(built)
                             except Exception: continue
 
         elif search_mode == 'local':
@@ -1369,6 +1454,8 @@ async def get_local_images(request):
                 if not check_tags(item.get('tags', [])):
                     continue
                 if item['type'] != 'dir' and not check_rating(item.get('rating', 0)):
+                    continue
+                if item['type'] != 'dir' and not check_mask(item):
                     continue
                 if _type_visible(item['type']):
                     all_items_with_meta.append(item)
@@ -1495,6 +1582,7 @@ async def get_ui_state(request):
             "search_query": "",
             "search_scopes": ["current", "input", "output", "saved"],
             "filter_ratings": [],
+            "mask_filter": "",
             "recursive": False
         }
 

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -1221,6 +1221,12 @@ async def get_local_images(request):
     filter_tags = [tag.strip() for tag in filter_tags_str.split(',') if tag.strip()]
     filter_mode = request.query.get('filter_mode', 'OR').upper()
     combine_mode = request.query.get('combine_mode', 'AND').upper()
+    try:
+        min_rating = max(0, min(5, int(request.query.get('min_rating', 0))))
+        max_rating = max(0, min(5, int(request.query.get('max_rating', 5))))
+    except (ValueError, TypeError):
+        min_rating, max_rating = 0, 5
+    recursive = request.query.get('recursive', 'false').lower() == 'true'
 
     page = int(request.query.get('page', 1))
     per_page = int(request.query.get('per_page', 50))
@@ -1240,6 +1246,15 @@ async def get_local_images(request):
             else:
                 return any(ft in lower_item_tags for ft in filter_tags)
 
+        def check_rating(item_rating):
+            return min_rating <= item_rating <= max_rating
+
+        def _type_visible(item_type):
+            return (item_type == 'dir' or
+                    (show_images and item_type == 'image') or
+                    (show_videos and item_type == 'video') or
+                    (show_audio and item_type == 'audio'))
+
         if search_query:
             comfy_dir = os.path.dirname(os.path.dirname(NODE_DIR))
             roots = _resolve_scope_roots(search_scopes, directory)
@@ -1249,12 +1264,6 @@ async def get_local_images(request):
             is_fuzzy = search_result['fuzzy']
             comfy_prefix = comfy_dir.rstrip("/") + "/"
 
-            def _type_visible(item_type):
-                return (item_type == 'dir' or
-                        (show_images and item_type == 'image') or
-                        (show_videos and item_type == 'video') or
-                        (show_audio and item_type == 'audio'))
-
             if combine_mode == 'OR' and filter_tags:
                 # Union: items matching search OR items matching tags
                 seen_paths = set()
@@ -1262,6 +1271,8 @@ async def get_local_images(request):
                 for item in search_items:
                     if item['path'].startswith(comfy_prefix):
                         item = {**item, 'path': item['path'][len(comfy_prefix):]}
+                    if not check_rating(item.get('rating', 0)):
+                        continue
                     if _type_visible(item['type']):
                         all_items_with_meta.append(item)
                         seen_paths.add(item['path'])
@@ -1278,7 +1289,7 @@ async def get_local_images(request):
                     if not any(real_path.startswith(root) or real_path.rstrip(os.sep) + os.sep == root
                                for root in resolved_roots):
                         continue
-                    if os.path.exists(path) and check_tags(meta.get('tags', [])):
+                    if os.path.exists(path) and check_tags(meta.get('tags', [])) and check_rating(meta.get('rating', 0)):
                         ext = os.path.splitext(path)[1].lower()
                         item_type = _ext_to_type(ext)
                         if item_type and _type_visible(item_type):
@@ -1298,8 +1309,37 @@ async def get_local_images(request):
                         item = {**item, 'path': item['path'][len(comfy_prefix):]}
                     if not check_tags(item.get('tags', [])):
                         continue
+                    if not check_rating(item.get('rating', 0)):
+                        continue
                     if _type_visible(item['type']):
                         all_items_with_meta.append(item)
+
+        elif recursive and directory:
+            metadata = load_metadata()
+            norm_dir = directory.replace("\\", "/").rstrip("/") + "/"
+            comfy_dir = os.path.dirname(os.path.dirname(NODE_DIR))
+            for path, meta in metadata.items():
+                norm_path = path.replace("\\", "/")
+                if not os.path.isabs(norm_path):
+                    norm_path = os.path.join(comfy_dir, norm_path).replace("\\", "/")
+                if not norm_path.startswith(norm_dir):
+                    continue
+                if not check_rating(meta.get('rating', 0)):
+                    continue
+                if not check_tags(meta.get('tags', [])):
+                    continue
+                if not os.path.exists(norm_path):
+                    continue
+                ext = os.path.splitext(norm_path)[1].lower()
+                item_type = _ext_to_type(ext)
+                if item_type and _type_visible(item_type):
+                    try:
+                        stats = os.stat(norm_path)
+                        all_items_with_meta.append(
+                            _build_item(norm_path, os.path.basename(norm_path), stats, item_type, meta=meta)
+                        )
+                    except Exception:
+                        continue
 
         elif search_mode == 'global' and filter_tags:
             roots = _resolve_scope_roots(search_scopes, directory)
@@ -1310,7 +1350,7 @@ async def get_local_images(request):
                 if not any(real_path.startswith(root) or real_path.rstrip(os.sep) + os.sep == root for root in resolved_roots):
                     continue
                 if os.path.exists(path):
-                    if check_tags(meta.get('tags', [])):
+                    if check_tags(meta.get('tags', [])) and check_rating(meta.get('rating', 0)):
                         ext = os.path.splitext(path)[1].lower()
                         item_type = ''
                         if show_images and ext in SUPPORTED_IMAGE_EXTENSIONS: item_type = 'image'
@@ -1330,12 +1370,9 @@ async def get_local_images(request):
             for item in directory_items:
                 if not check_tags(item.get('tags', [])):
                     continue
-
-                item_type = item['type']
-                if (item_type == 'dir' or
-                    (show_images and item_type == 'image') or
-                    (show_videos and item_type == 'video') or
-                    (show_audio and item_type == 'audio')):
+                if item['type'] != 'dir' and not check_rating(item.get('rating', 0)):
+                    continue
+                if _type_visible(item['type']):
                     all_items_with_meta.append(item)
 
         if selected_paths:
@@ -1360,7 +1397,7 @@ async def get_local_images(request):
         elif sort_by == 'rating': all_items_with_meta.sort(key=lambda x: x.get('rating', 0), reverse=reverse_order)
         else: all_items_with_meta.sort(key=lambda x: x['name'].lower(), reverse=reverse_order)
 
-        is_search_result = bool(search_query) or (search_mode == 'global' and filter_tags)
+        is_search_result = bool(search_query) or (search_mode == 'global' and filter_tags) or recursive
 
         if not is_search_result:
             all_items_with_meta.sort(key=lambda x: x['type'] != 'dir')
@@ -1458,7 +1495,10 @@ async def get_ui_state(request):
             "show_audio": False,
             "filter_tag": "",
             "search_query": "",
-            "search_scopes": ["current", "input", "output", "saved"]
+            "search_scopes": ["current", "input", "output", "saved"],
+            "min_rating": 0,
+            "max_rating": 5,
+            "recursive": False
         }
 
         node_saved_state = ui_states.get(node_key, {})

--- a/Local_Media_Manager.py
+++ b/Local_Media_Manager.py
@@ -1221,11 +1221,14 @@ async def get_local_images(request):
     filter_tags = [tag.strip() for tag in filter_tags_str.split(',') if tag.strip()]
     filter_mode = request.query.get('filter_mode', 'OR').upper()
     combine_mode = request.query.get('combine_mode', 'AND').upper()
-    try:
-        min_rating = max(0, min(5, int(request.query.get('min_rating', 0))))
-        max_rating = max(0, min(5, int(request.query.get('max_rating', 5))))
-    except (ValueError, TypeError):
-        min_rating, max_rating = 0, 5
+    filter_ratings_str = request.query.get('filter_ratings', '').strip()
+    if filter_ratings_str:
+        try:
+            filter_ratings = set(int(r) for r in filter_ratings_str.split(',') if r.strip())
+        except ValueError:
+            filter_ratings = None
+    else:
+        filter_ratings = None
     recursive = request.query.get('recursive', 'false').lower() == 'true'
 
     page = int(request.query.get('page', 1))
@@ -1247,7 +1250,9 @@ async def get_local_images(request):
                 return any(ft in lower_item_tags for ft in filter_tags)
 
         def check_rating(item_rating):
-            return min_rating <= item_rating <= max_rating
+            if filter_ratings is None:
+                return True
+            return item_rating in filter_ratings
 
         def _type_visible(item_type):
             return (item_type == 'dir' or
@@ -1315,31 +1320,24 @@ async def get_local_images(request):
                         all_items_with_meta.append(item)
 
         elif recursive and directory:
-            metadata = load_metadata()
-            norm_dir = directory.replace("\\", "/").rstrip("/") + "/"
-            comfy_dir = os.path.dirname(os.path.dirname(NODE_DIR))
-            for path, meta in metadata.items():
-                norm_path = path.replace("\\", "/")
-                if not os.path.isabs(norm_path):
-                    norm_path = os.path.join(comfy_dir, norm_path).replace("\\", "/")
-                if not norm_path.startswith(norm_dir):
+            # BFS using per-directory cache — each subdir is individually cached
+            dirs_to_scan = [directory]
+            while dirs_to_scan:
+                current_dir = dirs_to_scan.pop()
+                dir_items = await get_directory_data(current_dir, force_refresh)
+                if dir_items is None:
                     continue
-                if not check_rating(meta.get('rating', 0)):
-                    continue
-                if not check_tags(meta.get('tags', [])):
-                    continue
-                if not os.path.exists(norm_path):
-                    continue
-                ext = os.path.splitext(norm_path)[1].lower()
-                item_type = _ext_to_type(ext)
-                if item_type and _type_visible(item_type):
-                    try:
-                        stats = os.stat(norm_path)
-                        all_items_with_meta.append(
-                            _build_item(norm_path, os.path.basename(norm_path), stats, item_type, meta=meta)
-                        )
-                    except Exception:
+                for item in dir_items:
+                    if item['type'] == 'dir':
+                        dirs_to_scan.append(item['path'])
                         continue
+                    if not _type_visible(item['type']):
+                        continue
+                    if not check_tags(item.get('tags', [])):
+                        continue
+                    if not check_rating(item.get('rating', 0)):
+                        continue
+                    all_items_with_meta.append(item)
 
         elif search_mode == 'global' and filter_tags:
             roots = _resolve_scope_roots(search_scopes, directory)
@@ -1496,8 +1494,7 @@ async def get_ui_state(request):
             "filter_tag": "",
             "search_query": "",
             "search_scopes": ["current", "input", "output", "saved"],
-            "min_rating": 0,
-            "max_rating": 5,
+            "filter_ratings": [],
             "recursive": False
         }
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ To support powerful new features like video processing and safe file deletion, t
 * **`torchaudio`**: Enables audio processing for the `Select Original Audio` and `Select Original Video` nodes.
 * **`send2trash`**: Ensures that deleting files is safer by sending them to the system's Recycle Bin/Trash instead of permanently deleting them.
 
+**Video Backend — PyAV:**
+
+The node uses **PyAV** (the `av` Python package) as its **primary backend** for video thumbnails, video metadata, and loading video frames. PyAV bundles a modern FFmpeg build with `libdav1d`, so it decodes **AV1** (the modern codec used by YouTube and much web video) in-process — fast, no external process, and no system `ffmpeg` required on `PATH`.
+
+When PyAV is not available in the environment, the node automatically falls back to **OpenCV** (`opencv-python`/`cv2`). Note that OpenCV's bundled FFmpeg cannot software-decode AV1, so AV1 files will fail on the cv2 fallback — PyAV is what makes AV1 work reliably. Both `av` and `opencv-python` are listed in `requirements.txt` and installed automatically with the node; no manual setup is needed.
+
 **Installation:**
 The easiest way to install these is through the **ComfyUI Manager**. After updating the custom node, the manager should detect the missing dependencies and prompt you to install them.
 

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -1,6 +1,30 @@
 import { app } from "/scripts/app.js";
 import { api } from "/scripts/api.js";
 
+const _lmmCache = {
+    tags: { promise: null, ts: 0 },
+    paths: { promise: null, ts: 0 },
+    TTL: 2000
+};
+
+function fetchTagsCached() {
+    const now = Date.now();
+    if (_lmmCache.tags.promise && (now - _lmmCache.tags.ts) < _lmmCache.TTL)
+        return _lmmCache.tags.promise;
+    _lmmCache.tags.ts = now;
+    _lmmCache.tags.promise = api.fetchApi("/local_image_gallery/get_all_tags").then(r => r.json());
+    return _lmmCache.tags.promise;
+}
+
+function fetchPathsCached() {
+    const now = Date.now();
+    if (_lmmCache.paths.promise && (now - _lmmCache.paths.ts) < _lmmCache.TTL)
+        return _lmmCache.paths.promise;
+    _lmmCache.paths.ts = now;
+    _lmmCache.paths.promise = api.fetchApi("/local_image_gallery/get_saved_paths").then(r => r.json());
+    return _lmmCache.paths.promise;
+}
+
 const githubPath = new Path2D("M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297 24 5.67 18.627.297 12 .297z");
 
 function addGitHubIcon(nodeType, url) {
@@ -1208,13 +1232,13 @@ app.registerExtension({
                         await api.fetchApi("/local_image_gallery/save_paths", {
                             method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ paths }),
                         });
+                        _lmmCache.paths.promise = null;
                     } catch (e) { console.error("Failed to save paths:", e); }
                 }
 
                 async function loadAllTags() {
                     try {
-                        const response = await api.fetchApi("/local_image_gallery/get_all_tags");
-                        const data = await response.json();
+                        const data = await fetchTagsCached();
                         multiSelectTagDropdown.innerHTML = '';
                         if (data.tags) {
                             data.tags.forEach(tag => {
@@ -1303,6 +1327,7 @@ app.registerExtension({
                             });
 
                             await Promise.all(updatePromises);
+                            _lmmCache.tags.promise = null;
                             await loadAllTags();
                             renderTagEditor();
 
@@ -1874,6 +1899,7 @@ app.registerExtension({
                             });
 
                             await Promise.all(updatePromises);
+                            _lmmCache.tags.promise = null;
                             await loadAllTags();
                             renderTagEditor();
                             tagEditorInput.value = "";
@@ -2204,8 +2230,7 @@ app.registerExtension({
 
                 const loadSavedPaths = async () => {
                     try {
-                        const response = await api.fetchApi("/local_image_gallery/get_saved_paths");
-                        const data = await response.json();
+                        const data = await fetchPathsCached();
                         pathPresets.innerHTML = '<option value="" disabled selected>Select a common path</option>';
                         if (data.saved_paths) {
                             data.saved_paths.forEach(p => {
@@ -2231,6 +2256,7 @@ app.registerExtension({
                     }
                 });
 
+                // Defer 1ms: LiteGraph hasn't wired this.widgets/setProperty yet when nodeCreated returns
                 setTimeout(() => initializeNode.call(this), 1);
                 loadSavedPaths();
                 loadAllTags();

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -668,7 +668,8 @@ app.registerExtension({
                         #${uniqueId} .lmm-scope-icons span { cursor: pointer; transition: opacity 0.15s; user-select: none; }
                         #${uniqueId} .lmm-scope-icons span.inactive { opacity: 0.2; }
                         #${uniqueId} .lmm-scope-icons .lmm-scope-divider { width: 1px; height: 14px; background: #555; margin: 0 2px; cursor: default; }
-                        #${uniqueId} .lmm-search-status { display: none; position: sticky; top: 0; left: 50%; transform: translateX(-50%); font-size: 11px; color: #aaa; padding: 1px 8px; white-space: nowrap; z-index: 5; pointer-events: none; background: rgba(26, 26, 26, 0.95); border-radius: 0 0 4px 4px; border: 1px solid #333; border-top: none; width: fit-content; }
+                        #${uniqueId} .lmm-search-status { display: none; height: 0; overflow: visible; text-align: center; font-size: 11px; color: #aaa; pointer-events: none; z-index: 5; position: relative; }
+                        #${uniqueId} .lmm-search-status > span { background: rgba(26, 26, 26, 0.95); border-radius: 0 0 4px 4px; border: 1px solid #333; border-top: none; padding: 1px 8px; white-space: nowrap; }
                     </style>
                     <div class="lmm-container-wrapper">
                          <div class="lmm-controls lmm-top-bar">
@@ -737,8 +738,8 @@ app.registerExtension({
                                 <button class="lmm-rename-btn">✔️</button>
                             </div>
                             </div>
+                        <div class="lmm-search-status"><span></span></div>
                         <div class="lmm-cardholder">
-                            <div class="lmm-search-status"></div>
                             <div class="lmm-gallery-placeholder">Enter folder path and click 'Refresh'.</div>
                         </div>
                     </div>
@@ -767,7 +768,7 @@ app.registerExtension({
                 const multiSelectTagDisplay = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-display");
                 const multiSelectTagDropdown = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-dropdown");
                 const searchInput = controls.querySelector(".lmm-search-input");
-                const searchStatus = cardholder.querySelector(".lmm-search-status");
+                const searchStatus = controls.querySelector(".lmm-search-status");
                 const searchScopeContainer = controls.querySelector(".lmm-search-scope-container");
                 const scopeIcons = searchScopeContainer.querySelectorAll(".lmm-scope-icons span[data-scope]");
                 const scopeAllToggle = searchScopeContainer.querySelector(".lmm-scope-all");
@@ -1095,6 +1096,7 @@ app.registerExtension({
                         }
 
                         let imagePartHeight = actualCardWidth / aspectRatio;
+
 
                         if (item.type === 'image' || item.type === 'video') {
                             imagePartHeight = Math.max(imagePartHeight, 100);
@@ -1470,6 +1472,9 @@ app.registerExtension({
                                 debouncedLayout();
                             }
                         };
+                        if (img.complete && img.naturalWidth > 0) {
+                            img.onload();
+                        }
                     }
 
                     return card;
@@ -1542,6 +1547,7 @@ app.registerExtension({
                         allItems = [];
                         calculateFullLayout();
                         cardholder.style.opacity = 1;
+                        searchStatus.style.display = 'none';
                         isLoading = false;
                         return;
                     }
@@ -1597,7 +1603,7 @@ app.registerExtension({
                             statusParts.push(`Tags: ${filterTag}`);
                         }
                         if (statusParts.length) {
-                            searchStatus.textContent = '\uD83D\uDD0D ' + statusParts.join(' + ');
+                            searchStatus.querySelector('span').textContent = '\uD83D\uDD0D ' + statusParts.join(' + ');
                             searchStatus.style.display = 'block';
                         } else {
                             searchStatus.style.display = 'none';
@@ -1608,6 +1614,7 @@ app.registerExtension({
                         if (!append) {
                             allItems = items;
                             cardholder.innerHTML = '';
+                            cardholder.appendChild(placeholder);
                             cardholder.scrollTop = 0;
                         } else {
                             const existingPaths = new Set(allItems.map(i => i.path));

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -1796,7 +1796,7 @@ app.registerExtension({
                                     if (currentSearchScopes.includes('input')) dirScopes.push('input/');
                                     if (currentSearchScopes.includes('output')) dirScopes.push('output/');
                                 }
-                                if (dirScopes.length) scopeParts.push(dirScopes.join(', '));
+                                if (dirScopes.length) scopeParts.push([...new Set(dirScopes)].join(', '));
                                 if (currentSearchScopes.includes('saved')) scopeParts.push('all saved paths');
                                 scopeLabel = scopeParts.join(' and ');
                             }

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -584,7 +584,7 @@ app.registerExtension({
                         #${uniqueId} .lmm-tag-editor-list .lmm-tag .lmm-remove-tag { margin-left: 4px; color: #fdd; cursor: pointer; font-weight: bold; }
                         #${uniqueId} .lmm-show-selected-btn.active { background-color: #4A90E2; color: white; border-color: #4A90E2; }
                         #${uniqueId} .lmm-tag-filter-wrapper { display: flex; flex-grow: 1; position: relative; align-items: center; }
-                        #${uniqueId} .lmm-tag-filter-wrapper input { flex-grow: 1; }
+                        #${uniqueId} .lmm-tag-filter-wrapper input { flex-grow: 1; transition: box-shadow 0.2s; }
                         #${uniqueId} .lmm-multiselect-tag { position: relative; flex-grow: 1; }
                         #${uniqueId} .lmm-multiselect-tag-display {
                             background-color: #333; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px; font-size: 10px;
@@ -634,17 +634,17 @@ app.registerExtension({
                         #${uniqueId} .lmm-mask-editor-btn { background-color: #2a2a2a; border: 1px solid #555; color: #eee; padding: 4px 8px; border-radius: 4px; cursor: pointer; }
                         #${uniqueId} .lmm-mask-editor-btn:hover { background-color: #444; }
                         #${uniqueId} .lmm-search-wrapper { display: flex; flex-grow: 1; position: relative; align-items: center; }
-                        #${uniqueId} .lmm-search-wrapper input { flex-grow: 1; }
-                        #${uniqueId} .lmm-clear-search-button { background: none; display: none; position: absolute; right: 4px; border: none; color: #aaa; cursor: pointer; font-size: 14px; padding: 2px 4px; }
+                        #${uniqueId} .lmm-search-wrapper input { flex-grow: 1; transition: box-shadow 0.2s; }
+                        #${uniqueId} .lmm-search-input:not(:placeholder-shown) { box-shadow: 0 0 6px 1px rgba(59, 130, 246, 0.5); }
+                        #${uniqueId} .lmm-tag-filter-input:not(:placeholder-shown) { box-shadow: 0 0 6px 1px rgba(59, 130, 246, 0.5); }
+                        #${uniqueId} .lmm-clear-search-button { background: none; display: none; position: absolute; right: 0px; border: none; color: #aaa; cursor: pointer; font-size: 14px; padding: 2px 4px; }
                         #${uniqueId} .lmm-search-wrapper input:not(:placeholder-shown) + .lmm-clear-search-button { display: block; }
-                        #${uniqueId} .lmm-search-scope-container { position: relative; flex-shrink: 0; }
-                        #${uniqueId} .lmm-search-scope-display { background-color: #333; color: #eee; border: 1px solid #555; border-radius: 4px; padding: 2px 8px; cursor: pointer; display: flex; align-items: center; gap: 4px; white-space: nowrap; user-select: none; }
-                        #${uniqueId} .lmm-search-scope-arrow { font-size: 10px; transition: transform 0.2s; }
-                        #${uniqueId} .lmm-search-scope-arrow.open { transform: rotate(180deg); }
-                        #${uniqueId} .lmm-search-scope-dropdown { display: none; position: absolute; top: 100%; left: 0; background: #333; border: 1px solid #555; border-radius: 4px; padding: 4px 0; z-index: 100; min-width: 140px; }
-                        #${uniqueId} .lmm-scope-option { display: flex; align-items: center; gap: 6px; padding: 3px 8px; cursor: pointer; white-space: nowrap; color: #eee; font-size: 12px; }
-                        #${uniqueId} .lmm-scope-option:hover { background-color: #444; }
-                        #${uniqueId} .lmm-scope-option:first-child { border-bottom: 1px solid #555; padding-bottom: 5px; margin-bottom: 2px; }
+                        #${uniqueId} .lmm-search-scope-container { flex-shrink: 0; }
+                        #${uniqueId} .lmm-scope-icons { display: flex; gap: 2px; font-size: 14px; line-height: 1; align-items: center; }
+                        #${uniqueId} .lmm-scope-icons span { cursor: pointer; transition: opacity 0.15s; user-select: none; }
+                        #${uniqueId} .lmm-scope-icons span.inactive { opacity: 0.2; }
+                        #${uniqueId} .lmm-scope-icons .lmm-scope-divider { width: 1px; height: 14px; background: #555; margin: 0 2px; cursor: default; }
+                        #${uniqueId} .lmm-search-status { display: none; text-align: center; font-size: 11px; color: #aaa; padding: 2px 0; margin: -6px 0 -2px; }
                     </style>
                     <div class="lmm-container-wrapper">
                          <div class="lmm-controls lmm-top-bar">
@@ -664,24 +664,15 @@ app.registerExtension({
                         <div class="lmm-controls" style="gap: 5px;">
                             <label>Search:</label>
                             <div class="lmm-search-wrapper">
-                                <input type="text" class="lmm-search-input" placeholder="Search by filename... (Enter to search)">
+                                <input type="text" class="lmm-search-input" placeholder="Search by filename...">
                                 <button class="lmm-clear-search-button" title="Clear Search">✖️</button>
                             </div>
                             <label>in</label>
                             <div class="lmm-search-scope-container">
-                                <div class="lmm-search-scope-display">
-                                    <span class="lmm-search-scope-text">All</span>
-                                    <span class="lmm-search-scope-arrow">▼</span>
-                                </div>
-                                <div class="lmm-search-scope-dropdown">
-                                    <label class="lmm-scope-option"><input type="checkbox" value="all" checked> Check All</label>
-                                    <label class="lmm-scope-option"><input type="checkbox" value="current" checked> Current Dir</label>
-                                    <label class="lmm-scope-option"><input type="checkbox" value="input" checked> Input</label>
-                                    <label class="lmm-scope-option"><input type="checkbox" value="output" checked> Output</label>
-                                    <label class="lmm-scope-option"><input type="checkbox" value="saved" checked> Saved Paths</label>
-                                </div>
+                                <span class="lmm-scope-icons"><span data-scope="current">📂</span><span data-scope="input">📥</span><span data-scope="output">📤</span><span data-scope="saved">💾</span><span class="lmm-scope-divider"></span><span class="lmm-scope-all">🌐</span></span>
                             </div>
                         </div>
+                        <div class="lmm-search-status"></div>
                         <div class="lmm-controls" style="gap: 5px;">
                             <label>Sort by:</label> <select class="lmm-sort-by"> <option value="name">Name</option> <option value="date">Date</option> <option value="rating">Rating</option> </select>
                             <label>Order:</label> <select class="lmm-sort-order"> <option value="asc">Ascending</option> <option value="desc">Descending</option> </select>
@@ -752,56 +743,96 @@ app.registerExtension({
                 const multiSelectTagDisplay = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-display");
                 const multiSelectTagDropdown = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-dropdown");
                 const searchInput = controls.querySelector(".lmm-search-input");
+                const searchStatus = controls.querySelector(".lmm-search-status");
                 const searchScopeContainer = controls.querySelector(".lmm-search-scope-container");
-                const searchScopeDisplay = searchScopeContainer.querySelector(".lmm-search-scope-display");
-                const searchScopeDropdown = searchScopeContainer.querySelector(".lmm-search-scope-dropdown");
-                const searchScopeText = searchScopeContainer.querySelector(".lmm-search-scope-text");
-                const searchScopeArrow = searchScopeContainer.querySelector(".lmm-search-scope-arrow");
-                const scopeCheckAll = searchScopeDropdown.querySelector('input[value="all"]');
-                const scopeCheckboxes = searchScopeDropdown.querySelectorAll('input:not([value="all"])');
+                const scopeIcons = searchScopeContainer.querySelectorAll(".lmm-scope-icons span[data-scope]");
+                const scopeAllToggle = searchScopeContainer.querySelector(".lmm-scope-all");
+                const activeScopes = new Set(['current', 'input', 'output', 'saved']);
 
-                const getSelectedScopes = () => Array.from(scopeCheckboxes).filter(cb => cb.checked).map(cb => cb.value);
+                const getSelectedScopes = () => Array.from(activeScopes);
 
                 const updateScopeDisplay = () => {
-                    const selected = getSelectedScopes();
-                    const labels = { current: 'Current', input: 'Input', output: 'Output', saved: 'Saved' };
-                    if (selected.length === scopeCheckboxes.length) {
-                        searchScopeText.textContent = 'All';
-                    } else if (selected.length === 0) {
-                        searchScopeText.textContent = 'None';
-                    } else {
-                        searchScopeText.textContent = selected.map(v => labels[v] || v).join(', ');
-                    }
-                    scopeCheckAll.checked = selected.length === scopeCheckboxes.length;
-                    scopeCheckAll.indeterminate = selected.length > 0 && selected.length < scopeCheckboxes.length;
+                    scopeIcons.forEach(icon => {
+                        icon.classList.toggle('inactive', !activeScopes.has(icon.dataset.scope));
+                    });
+                    scopeAllToggle.classList.toggle('inactive', activeScopes.size < 4);
                 };
 
-                scopeCheckAll.addEventListener('change', () => {
-                    const shouldCheck = scopeCheckAll.checked;
-                    scopeCheckboxes.forEach(cb => { cb.checked = shouldCheck; });
+                scopeIcons.forEach(icon => {
+                    icon.addEventListener('click', () => {
+                        const scope = icon.dataset.scope;
+                        if (activeScopes.has(scope)) activeScopes.delete(scope);
+                        else activeScopes.add(scope);
                     updateScopeDisplay();
                     if (searchInput.value.trim()) saveStateAndReload(false);
                 });
-
-                scopeCheckboxes.forEach(cb => {
-                    cb.addEventListener('change', () => {
+                });
+                scopeAllToggle.addEventListener('click', () => {
+                    const allScopes = ['current', 'input', 'output', 'saved'];
+                    if (activeScopes.size === allScopes.length) {
+                        activeScopes.clear();
+                    } else {
+                        allScopes.forEach(s => activeScopes.add(s));
+                    }
                         updateScopeDisplay();
                         if (searchInput.value.trim()) saveStateAndReload(false);
                     });
+                
+                // Scope icon tooltips — appended to body to avoid transform containment
+                const scopeTip = document.createElement('div');
+                Object.assign(scopeTip.style, {
+                    position: 'fixed', background: '#1a1a1a', color: '#ccc', fontSize: '22px',
+                    padding: '8px 14px', borderRadius: '4px', border: '1px solid #444',
+                    pointerEvents: 'none', zIndex: '10000', whiteSpace: 'pre', lineHeight: '1.4',
+                    opacity: '0', transition: 'opacity 0.15s',
                 });
-
-                searchScopeDisplay.addEventListener('click', () => {
-                    const isVisible = searchScopeDropdown.style.display === 'block';
-                    searchScopeDropdown.style.display = isVisible ? 'none' : 'block';
-                    searchScopeArrow.classList.toggle('open', !isVisible);
-                });
-
-                document.addEventListener('click', (e) => {
-                    if (!searchScopeContainer.contains(e.target)) {
-                        searchScopeDropdown.style.display = 'none';
-                        searchScopeArrow.classList.remove('open');
+                document.body.appendChild(scopeTip);
+                let scopeTipTimer = null;
+                const scopeTipText = (el) => {
+                    const t = (text) => `<span style="color:#eee;font-weight:500">${text}</span>`;
+                    const d = (text) => `<span style="color:#999;font-size:20px">${text}</span>`;
+                    const scope = el.dataset.scope;
+                    if (scope === 'current') {
+                        let dir = pathInput.value.trim() || '(none)';
+                        if (dir !== '(none)' && !dir.endsWith('/')) dir = dir + '/';
+                        return t('Include current directory in search scope') + '\n' + d(dir);
                     }
+                    if (scope === 'input') return t('Include input directory in search scope');
+                    if (scope === 'output') return t('Include output directory in search scope');
+                    if (scope === 'saved') {
+                        const paths = Array.from(pathPresets.options).map(o => o.value).filter(Boolean);
+                        let detail = '';
+                        if (paths.length === 0) {
+                            detail = d('(none configured)');
+                        } else {
+                            const show = paths.slice(0, 10);
+                            detail = show.map(p => d(p)).join('\n');
+                            if (paths.length > 10) detail += '\n' + d(`  \u2026and ${paths.length - 10} more`);
+                    }
+                        return detail + '\n' + t('Include saved paths in search scope');
+                    }
+                    if (el.classList.contains('lmm-scope-all')) return t('Toggle all search scopes');
+                    return '';
+                };
+                const showScopeTip = (el) => {
+                    clearTimeout(scopeTipTimer);
+                    scopeTipTimer = setTimeout(() => {
+                        scopeTip.innerHTML = scopeTipText(el);
+                        scopeTip.style.opacity = '1';
+                        const rect = el.getBoundingClientRect();
+                        scopeTip.style.left = rect.left + rect.width / 2 - scopeTip.offsetWidth / 2 + 'px';
+                        scopeTip.style.top = rect.top - scopeTip.offsetHeight - 4 + 'px';
+                    }, 250);
+                };
+                const hideScopeTip = () => {
+                    clearTimeout(scopeTipTimer);
+                    scopeTip.style.opacity = '0';
+                };
+                searchScopeContainer.querySelectorAll('.lmm-scope-icons span:not(.lmm-scope-divider)').forEach(el => {
+                    el.addEventListener('mouseenter', () => showScopeTip(el));
+                    el.addEventListener('mouseleave', hideScopeTip);
                 });
+                
                 const clearSearchButton = controls.querySelector(".lmm-clear-search-button");
                 const tagEditor = controls.querySelector(".lmm-tag-editor");
                 const tagEditorInput = controls.querySelector(".lmm-tag-editor-input");
@@ -817,7 +848,7 @@ app.registerExtension({
                 
                 const renderBreadcrumb = (path) => {
                     breadcrumbEl.innerHTML = '';
-                    if (!path || path === "Selected Items" || path === "Global Search" || path.startsWith("Search: ")) {
+                    if (!path || path === "Selected Items") {
                         const staticItem = document.createElement('span');
                         staticItem.textContent = path || "Enter a path...";
                         staticItem.style.paddingLeft = '4px';
@@ -1495,13 +1526,27 @@ app.registerExtension({
                             lastKnownPath = api_data.current_directory;
                             renderBreadcrumb(api_data.current_directory);
                             setUiState.call(this, this.id, { last_path: api_data.current_directory });
-                        } else if (currentSearchQuery) {
+                        } else {
+                            renderBreadcrumb(lastKnownPath || '');
+                        }
+
+                        // Update search status indicator
+                        const filterTag = tagFilterInput.value.trim();
+                        const statusParts = [];
+                        if (currentSearchQuery) {
                             const scopeLabels = { current: 'Current Dir', input: 'Input', output: 'Output', saved: 'Saved Paths' };
                             const scopeLabel = currentSearchScopes.length === 4 ? 'All' : currentSearchScopes.map(s => scopeLabels[s] || s).join(', ');
-                            const fuzzyLabel = api_data.fuzzy ? ' (fuzzy match)' : '';
-                            renderBreadcrumb(`Search: "${currentSearchQuery}" in ${scopeLabel}${fuzzyLabel}`);
+                            const fuzzyLabel = api_data.fuzzy ? ' (fuzzy)' : '';
+                            statusParts.push(`File: "${currentSearchQuery}" in ${scopeLabel}${fuzzyLabel}`);
+                        }
+                        if (filterTag) {
+                            statusParts.push(`Tags: ${filterTag}`);
+                        }
+                        if (statusParts.length) {
+                            searchStatus.textContent = '\uD83D\uDD0D ' + statusParts.join(' + ');
+                            searchStatus.style.display = 'block';
                         } else {
-                            renderBreadcrumb("Global Search");
+                            searchStatus.style.display = 'none';
                         }
 
                         upButton.disabled = api_data.is_global_search || !parentDir;
@@ -1567,8 +1612,7 @@ app.registerExtension({
                         event.stopPropagation();
                         tagFilterInput.value = event.target.textContent;
                         lastFilteredTags = tagFilterInput.value.trim();
-                        scopeCheckAll.checked = true;
-                        scopeCheckboxes.forEach(cb => { cb.checked = true; });
+                        ['current', 'input', 'output', 'saved'].forEach(s => activeScopes.add(s));
                         updateScopeDisplay();
                         resetAndReload(true);
                         return;
@@ -1771,6 +1815,11 @@ app.registerExtension({
                         clearTimeout(tagFilterDebounceTimer);
                         lastFilteredTags = tagFilterInput.value.trim();
                         saveStateAndReload(false);
+                    } else if (e.key === 'Escape' && tagFilterInput.value) {
+                        e.preventDefault();
+                        tagFilterInput.focus();
+                        document.execCommand('selectAll');
+                        document.execCommand('delete');
                     }
                 });
                 
@@ -1832,6 +1881,11 @@ app.registerExtension({
                         clearTimeout(searchDebounceTimer);
                         lastSearchedQuery = searchInput.value.trim();
                         saveStateAndReload(false);
+                    } else if (e.key === 'Escape' && searchInput.value) {
+                        e.preventDefault();
+                        searchInput.focus();
+                        document.execCommand('selectAll');
+                        document.execCommand('delete');
                     }
                 });
                 clearSearchButton.addEventListener('click', () => {
@@ -1840,7 +1894,7 @@ app.registerExtension({
                     clearTimeout(searchDebounceTimer);
                     saveStateAndReload(false);
                 });
-                // Scope change handling is done in the scopeCheckAll/scopeCheckboxes listeners above
+                // Scope change handling is done in the scopeIcons click listeners above
                 
                 addPathButton.addEventListener('click', () => {
                     const currentPath = pathInput.value.trim();
@@ -2087,8 +2141,9 @@ app.registerExtension({
                             lastFilteredTags = (state.filter_tag || '').trim();
                             searchInput.value = state.search_query || '';
                             lastSearchedQuery = searchInput.value.trim();
-                            const activeScopes = state.search_scopes || (state.search_scope ? [state.search_scope] : ['current', 'input', 'output', 'saved']);
-                            scopeCheckboxes.forEach(cb => { cb.checked = activeScopes.includes(cb.value); });
+                            const savedScopes = state.search_scopes || (state.search_scope ? [state.search_scope] : ['current', 'input', 'output', 'saved']);
+                            activeScopes.clear();
+                            savedScopes.forEach(s => activeScopes.add(s));
                             updateScopeDisplay();
                             showSelectedMode = state.show_selected_mode || false;
                             

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -521,7 +521,7 @@ app.registerExtension({
                         #${uniqueId} .lmm-breadcrumb-ellipsis { color: #888; padding: 0 4px; user-select: none; font-weight: bold; }
                         
                         #${uniqueId} .lmm-cardholder { position: relative; overflow-y: auto; overflow-x: hidden; background: #222; padding: 0; border-radius: 5px; flex-grow: 1; min-height: 0; height: 0; width: 100%; transition: opacity 0.2s ease-in-out; box-sizing: border-box; }
-                        #${uniqueId} .lmm-gallery-card { position: absolute; border: 3px solid transparent; border-radius: 8px; box-sizing: border-box; transition: all 0.3s ease; display: flex; flex-direction: column; background-color: var(--comfy-input-bg); }
+                        #${uniqueId} .lmm-gallery-card { position: absolute; border: 3px solid transparent; border-radius: 8px; box-sizing: border-box; transition: all 0.3s ease; display: flex; flex-direction: column; background-color: #333; }
                         #${uniqueId} .lmm-gallery-card.lmm-selected { border-color: #00FFC9; }
                         #${uniqueId} .lmm-gallery-card.lmm-edit-selected { border-color: #FFD700; box-shadow: 0 0 10px #FFD700; }
                         #${uniqueId} .lmm-selection-badge {
@@ -561,8 +561,8 @@ app.registerExtension({
                         #${uniqueId} .lmm-video-card-overlay { position: absolute; top: 5px; left: 5px; width: 24px; height: 24px; opacity: 0.8; pointer-events: none; }
                         
                         #${uniqueId} .lmm-card-info-panel { 
-                            flex-shrink: 0; background-color: var(--comfy-input-bg); 
-                            padding: 4px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; 
+                            flex-shrink: 0; background-color: inherit;
+                            padding: 2px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px; 
                             min-height: 48px; position: relative;
                             display: flex; flex-direction: column; align-items: flex-start;
                             box-sizing: border-box;
@@ -590,9 +590,11 @@ app.registerExtension({
                             background-color: rgba(80,80,80,0.6);
                         }
                         
-                        #${uniqueId} .edit-tags-btn { position: absolute; bottom: 4px; right: 4px; width: 22px; height: 22px; background-color: rgba(0,0,0,0.5); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; transition: background-color 0.2s; opacity: 0; cursor: pointer; }
-                        #${uniqueId} .lmm-gallery-card:hover .edit-tags-btn { opacity: 1; }
-                        #${uniqueId} .edit-tags-btn:hover { background-color: rgba(0,0,0,0.8); }
+                        #${uniqueId} .edit-tags-btn, #${uniqueId} .open-media-btn { position: absolute; bottom: 2px; width: 22px; height: 22px; background-color: rgba(0,0,0,0.5); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; transition: background-color 0.2s; opacity: 0; cursor: pointer; }
+                        #${uniqueId} .open-media-btn { right: 2px; }
+                        #${uniqueId} .edit-tags-btn { right: 28px; }
+                        #${uniqueId} .lmm-gallery-card:hover .edit-tags-btn, #${uniqueId} .lmm-gallery-card:hover .open-media-btn { opacity: 1; }
+                        #${uniqueId} .edit-tags-btn:hover, #${uniqueId} .open-media-btn:hover { background-color: rgba(0,0,0,0.8); }
                         #${uniqueId} .lmm-star-rating { font-size: 16px; cursor: pointer; color: #555; }
                         #${uniqueId} .lmm-star-rating .lmm-star:hover { color: #FFD700 !important; }
                         #${uniqueId} .lmm-star-rating .lmm-star.lmm-rated { color: #FFC700; }
@@ -1241,7 +1243,7 @@ app.registerExtension({
                 const debounce = (func, delay) => { let timeoutId; return (...args) => { clearTimeout(timeoutId); timeoutId = setTimeout(() => func.apply(this, args), delay); }; };
 
                 const calculateFullLayout = () => {
-                    const minCardWidth = 150, gap = 5, containerWidth = cardholder.clientWidth;
+                    const minCardWidth = 150, gap = 3, containerWidth = cardholder.clientWidth;
                     if (containerWidth === 0 || allItems.length === 0) {
                         cardholder.style.height = '0px';
                         layoutData = [];
@@ -1274,7 +1276,8 @@ app.registerExtension({
                             aspectRatio = 1.0;
                         }
 
-                        let imagePartHeight = actualCardWidth / aspectRatio;
+                        const cardBorder = 6; // 3px border each side (box-sizing: border-box)
+                        let imagePartHeight = (actualCardWidth - cardBorder) / aspectRatio;
 
 
                         if (item.type === 'image' || item.type === 'video') {
@@ -1296,7 +1299,7 @@ app.registerExtension({
                             measuringDiv.innerHTML = infoPanelHTML;
 
                             const infoPanelHeight = measuringDiv.querySelector('.lmm-card-info-panel').offsetHeight + 2;
-                            var cardHeight = imagePartHeight + infoPanelHeight;
+                            var cardHeight = imagePartHeight + infoPanelHeight + cardBorder;
                         } else {
                             var cardHeight = 150;
                         }
@@ -1530,7 +1533,11 @@ app.registerExtension({
                     card.dataset.type = item.type;
                     card.dataset.tags = item.tags.join(',');
                     card.dataset.rating = item.rating;
-                    card.title = item.name;
+                    const dir = item.path.substring(0, item.path.length - item.name.length);
+                    const d = new Date(item.mtime * 1000);
+                    const pad = (n) => String(n).padStart(2, '0');
+                    const mtimeStr = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+                    card.title = `Name: ${item.name}\nPath: ${dir}\nType: ${item.type}\nLast Edited: ${mtimeStr}`;
 
                     let mediaHTML = "";
                     if (item.type === 'dir') {
@@ -1558,6 +1565,7 @@ app.registerExtension({
                                 ${workflowTextBadge}
                             </div>
                             <div class="lmm-tag-list">${tags}</div>
+                            <div class="open-media-btn">🔎</div>
                             <div class="edit-tags-btn">✏️</div>
                         `;
                         card.appendChild(infoPanel);
@@ -1619,6 +1627,14 @@ app.registerExtension({
                                 }
                             }
                             renderTagEditor();
+                        });
+
+                        const openBtn = infoPanel.querySelector(".open-media-btn");
+                        openBtn.addEventListener("click", (e) => {
+                            e.stopPropagation();
+                            const currentMediaList = allItems.filter(i => ['image', 'video', 'audio'].includes(i.type));
+                            const idx = currentMediaList.findIndex(i => i.path === item.path);
+                            if (idx !== -1) showMediaAtIndex(idx, currentMediaList);
                         });
 
                         const starRating = infoPanel.querySelector('.lmm-star-rating');

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -615,8 +615,7 @@ app.registerExtension({
                             border-radius: 4px; cursor: pointer; flex-shrink: 0;
                         }
                         #${uniqueId} .lmm-clear-tag-filter-button {
-                            background: none;
-                            display: none;
+                            background: none; display: none; position: absolute; right: 0px; border: none; color: #aaa; cursor: pointer; font-size: 14px; padding: 2px 4px;
                         }
                         #${uniqueId} .lmm-tag-filter-wrapper input:not(:placeholder-shown) + .lmm-clear-tag-filter-button {
                             display: block;

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -638,6 +638,10 @@ app.registerExtension({
                             padding: 4px 8px; background-color: #555; color: #fff; border: 1px solid #666;
                             border-radius: 4px; cursor: pointer; flex-shrink: 0;
                         }
+                        #${uniqueId} .lmm-combine-mode-btn {
+                            padding: 4px 8px; background-color: #555; color: #fff; border: 1px solid #666;
+                            border-radius: 4px; cursor: pointer; flex-shrink: 0;
+                        }
                         #${uniqueId} .lmm-clear-tag-filter-button {
                             background: none; display: none; position: absolute; right: 0px; border: none; color: #aaa; cursor: pointer; font-size: 14px; padding: 2px 4px;
                         }
@@ -701,17 +705,8 @@ app.registerExtension({
                             </div>
                         </div>
                         <div class="lmm-controls" style="gap: 5px;">
-                            <label>Sort by:</label> <select class="lmm-sort-by"> <option value="name">Name</option> <option value="date">Date</option> <option value="rating">Rating</option> </select>
-                            <label>Order:</label> <select class="lmm-sort-order"> <option value="asc">Ascending</option> <option value="desc">Descending</option> </select>
-                            <div style="margin-left: auto; display: flex; align-items: center; gap: 5px;">
-                                <label>Images:</label> <input type="checkbox" class="lmm-show-images" checked>
-                                <label>Videos:</label> <input type="checkbox" class="lmm-show-videos">
-                                <label>Audio:</label> <input type="checkbox" class="lmm-show-audio">
-                                <button class="lmm-show-selected-btn" title="Show all selected items across folders">Show Selected</button>
-                            </div>
-                        </div>
-                        <div class="lmm-controls" style="gap: 5px;">
-                            <label>Filter by Tag:</label>
+                            <button class="lmm-combine-mode-btn" title="Switch how search query and tag filter combine (AND: both must match, OR: either can match)">AND</button>
+                            <label>by Tag:</label>
                             <button class="lmm-tag-filter-mode-btn" title="Click to switch filter logic (OR/AND)">OR</button>
                             <div class="lmm-tag-filter-wrapper">
                                 <input type="text" class="lmm-tag-filter-input" placeholder="Enter tags, separated by commas...">
@@ -726,9 +721,19 @@ app.registerExtension({
                             </div>
                             <div style="margin-left: auto; display: flex; gap: 5px;">
                                 <button class="lmm-mask-editor-btn" title="Open Mask Editor for selected image">Mask Editor</button>
-                                <button class="lmm-batch-action-btn lmm-batch-select-all-btn" title="Select All Files in Current View">All</button>
                                 <button class="lmm-batch-action-btn lmm-batch-move-btn" title="Move Selected Files" disabled>➔ Move</button>
                                 <button class="lmm-batch-action-btn lmm-batch-delete-btn" title="Delete Selected Files" disabled>🗑️ Delete</button>
+                            </div>
+                        </div>
+                        <div class="lmm-controls" style="gap: 5px;">
+                            <label>Sort by:</label> <select class="lmm-sort-by"> <option value="name">Name</option> <option value="date">Date</option> <option value="rating">Rating</option> </select>
+                            <label>Order:</label> <select class="lmm-sort-order"> <option value="asc">Ascending</option> <option value="desc">Descending</option> </select>
+                            <div style="margin-left: auto; display: flex; align-items: center; gap: 5px;">
+                                <label>Images:</label> <input type="checkbox" class="lmm-show-images" checked>
+                                <label>Videos:</label> <input type="checkbox" class="lmm-show-videos">
+                                <label>Audio:</label> <input type="checkbox" class="lmm-show-audio">
+                                <button class="lmm-show-selected-btn" title="Show all selected items across folders">Show Selected</button>
+                                <button class="lmm-batch-action-btn lmm-batch-select-all-btn" title="Select All Files in Current View">Select All</button>
                             </div>
                         </div>
                         <div class="lmm-controls lmm-tag-editor">
@@ -767,6 +772,7 @@ app.registerExtension({
                 const showAudioCheckbox = controls.querySelector(".lmm-show-audio");
                 const tagFilterInput = controls.querySelector(".lmm-tag-filter-input");
                 const tagFilterModeBtn = controls.querySelector(".lmm-tag-filter-mode-btn");
+                const combineModeBtn = controls.querySelector(".lmm-combine-mode-btn");
                 const multiSelectTagContainer = controls.querySelector(".lmm-multiselect-tag");
                 const multiSelectTagDisplay = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-display");
                 const multiSelectTagDropdown = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-dropdown");
@@ -1713,6 +1719,7 @@ app.registerExtension({
                     const currentSearchScopes = getSelectedScopes();
                     const isGlobalSearch = !!(currentSearchQuery) || (filterTag && !(currentSearchScopes.length === 1 && currentSearchScopes[0] === 'current'));
                     const filterMode = tagFilterModeBtn.textContent;
+                    const combineMode = combineModeBtn.textContent;
 
                     if (!directory && !isGlobalSearch && !currentSearchQuery) {
                         placeholder.textContent = "Enter folder path and click 'Refresh'.";
@@ -1738,7 +1745,7 @@ app.registerExtension({
                     } else if (filterTag && !(currentSearchScopes.length === 1 && currentSearchScopes[0] === 'current')) {
                         searchMode = 'global';
                     }
-                    let url = `/local_image_gallery/images?directory=${encodeURIComponent(directory)}&page=${page}&sort_by=${sortBy}&sort_order=${sortOrder}&show_images=${showImages}&show_videos=${showVideos}&show_audio=${showAudio}&filter_tag=${encodeURIComponent(filterTag)}&search_mode=${searchMode}&filter_mode=${filterMode}&force_refresh=${forceRefresh}&search_query=${encodeURIComponent(currentSearchQuery)}`;
+                    let url = `/local_image_gallery/images?directory=${encodeURIComponent(directory)}&page=${page}&sort_by=${sortBy}&sort_order=${sortOrder}&show_images=${showImages}&show_videos=${showVideos}&show_audio=${showAudio}&filter_tag=${encodeURIComponent(filterTag)}&search_mode=${searchMode}&filter_mode=${filterMode}&combine_mode=${combineMode}&force_refresh=${forceRefresh}&search_query=${encodeURIComponent(currentSearchQuery)}`;
                     currentSearchScopes.forEach(s => { url += `&search_scope=${encodeURIComponent(s)}`; });
 
                     if (selection.length > 0) {
@@ -1800,7 +1807,8 @@ app.registerExtension({
                                 if (currentSearchScopes.includes('saved')) scopeParts.push('all saved paths');
                                 scopeLabel = scopeParts.join(' and ');
                             }
-                            searchStatus.querySelector('span').textContent = `\uD83D\uDD0D Searching media with ${criteriaParts.join(' and ')} in ${scopeLabel}`;
+                            const criteriaJoiner = (hasQuery && hasTags && combineMode === 'OR') ? ' or ' : ' and ';
+                            searchStatus.querySelector('span').textContent = `\uD83D\uDD0D Searching media with ${criteriaParts.join(criteriaJoiner)} in ${scopeLabel}`;
                             searchStatus.style.display = 'block';
                         } else {
                             searchStatus.style.display = 'none';
@@ -2028,6 +2036,8 @@ app.registerExtension({
                         show_videos: showVideosCheckbox.checked,
                         show_audio: showAudioCheckbox.checked,
                         filter_tag: tagFilterInput.value,
+                        filter_mode: tagFilterModeBtn.textContent,
+                        combine_mode: combineModeBtn.textContent,
                         search_query: searchInput.dataset.savedValue || searchInput.value,
                         search_scopes: getSelectedScopes(),
                         show_selected_mode: showSelectedMode,
@@ -2221,6 +2231,17 @@ app.registerExtension({
                     saveStateAndReload(false);
                 });
 
+                combineModeBtn.addEventListener('click', () => {
+                    if (combineModeBtn.textContent === 'AND') {
+                        combineModeBtn.textContent = 'OR';
+                        combineModeBtn.style.backgroundColor = "#2563EB";
+                    } else {
+                        combineModeBtn.textContent = 'AND';
+                        combineModeBtn.style.backgroundColor = "#555";
+                    }
+                    saveStateAndReload(false);
+                });
+
                 const updateShowSelectedButtonUI = () => {
                     if (showSelectedMode) {
                         showSelectedButton.classList.add('active');
@@ -2408,6 +2429,15 @@ app.registerExtension({
                             savedScopes.forEach(s => activeScopes.add(s));
                             updateScopeDisplay();
                             showSelectedMode = state.show_selected_mode || false;
+
+                            if (state.filter_mode) {
+                                tagFilterModeBtn.textContent = state.filter_mode;
+                                tagFilterModeBtn.style.backgroundColor = state.filter_mode === 'AND' ? '#D97706' : '#555';
+                            }
+                            if (state.combine_mode) {
+                                combineModeBtn.textContent = state.combine_mode;
+                                combineModeBtn.style.backgroundColor = state.combine_mode === 'OR' ? '#2563EB' : '#555';
+                            }
 
                             selection = state.selection || [];
                             updateBatchActionButtonsState();

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -668,7 +668,7 @@ app.registerExtension({
                         #${uniqueId} .lmm-scope-icons span { cursor: pointer; transition: opacity 0.15s; user-select: none; }
                         #${uniqueId} .lmm-scope-icons span.inactive { opacity: 0.2; }
                         #${uniqueId} .lmm-scope-icons .lmm-scope-divider { width: 1px; height: 14px; background: #555; margin: 0 2px; cursor: default; }
-                        #${uniqueId} .lmm-search-status { display: none; position: absolute; top: 100%; left: 50%; transform: translateX(-50%); font-size: 11px; color: #aaa; padding: 1px 8px; white-space: nowrap; z-index: 5; pointer-events: none; background: rgba(26, 26, 26, 0.95); border-radius: 0 0 4px 4px; border: 1px solid #333; border-top: none; }
+                        #${uniqueId} .lmm-search-status { display: none; position: sticky; top: 0; left: 50%; transform: translateX(-50%); font-size: 11px; color: #aaa; padding: 1px 8px; white-space: nowrap; z-index: 5; pointer-events: none; background: rgba(26, 26, 26, 0.95); border-radius: 0 0 4px 4px; border: 1px solid #333; border-top: none; width: fit-content; }
                     </style>
                     <div class="lmm-container-wrapper">
                          <div class="lmm-controls lmm-top-bar">
@@ -690,7 +690,6 @@ app.registerExtension({
                             <div class="lmm-search-wrapper">
                                 <input type="text" class="lmm-search-input" placeholder="Search by filename...">
                                 <button class="lmm-clear-search-button" title="Clear Search">✖️</button>
-                                <div class="lmm-search-status"></div>
                             </div>
                             <label>in</label>
                             <div class="lmm-search-scope-container">
@@ -739,6 +738,7 @@ app.registerExtension({
                             </div>
                             </div>
                         <div class="lmm-cardholder">
+                            <div class="lmm-search-status"></div>
                             <div class="lmm-gallery-placeholder">Enter folder path and click 'Refresh'.</div>
                         </div>
                     </div>
@@ -767,7 +767,7 @@ app.registerExtension({
                 const multiSelectTagDisplay = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-display");
                 const multiSelectTagDropdown = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-dropdown");
                 const searchInput = controls.querySelector(".lmm-search-input");
-                const searchStatus = controls.querySelector(".lmm-search-status");
+                const searchStatus = cardholder.querySelector(".lmm-search-status");
                 const searchScopeContainer = controls.querySelector(".lmm-search-scope-container");
                 const scopeIcons = searchScopeContainer.querySelectorAll(".lmm-scope-icons span[data-scope]");
                 const scopeAllToggle = searchScopeContainer.querySelector(".lmm-scope-all");

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -16,41 +16,41 @@ function addGitHubIcon(nodeType, url) {
         const y = (LiteGraph.NODE_TITLE_HEIGHT - iconSize) / 2 - LiteGraph.NODE_TITLE_HEIGHT;
 
         this.githubIconRect = [x, y, iconSize, iconSize];
-        
+
         ctx.save();
         ctx.translate(x, y);
         ctx.scale(iconSize / 24, iconSize / 24);
-        
+
         ctx.fillStyle = this.mouseOver && this.mouseOver_github_icon ? "#FFFFFF" : "#888888";
-        
+
         ctx.fill(githubPath);
         ctx.restore();
     };
 
     const onMouseDown = nodeType.prototype.onMouseDown;
-    nodeType.prototype.onMouseDown = function(e, pos, graphcanvas) {
+    nodeType.prototype.onMouseDown = function (e, pos, graphcanvas) {
         if (this.flags.collapsed) {
-             return onMouseDown?.apply(this, arguments);
+            return onMouseDown?.apply(this, arguments);
         }
         if (this.githubIconRect && pos[1] < LiteGraph.NODE_TITLE_HEIGHT) {
             const [x, y, w, h] = this.githubIconRect;
             if (pos[0] > x && pos[0] < x + w && pos[1] > y && pos[1] < y + h) {
                 window.open(url, '_blank');
-                return true; 
+                return true;
             }
         }
         return onMouseDown?.apply(this, arguments);
     };
 
     const onMouseMove = nodeType.prototype.onMouseMove;
-    nodeType.prototype.onMouseMove = function(e, pos, graphcanvas) {
+    nodeType.prototype.onMouseMove = function (e, pos, graphcanvas) {
         if (this.flags.collapsed) {
             return onMouseMove?.apply(this, arguments);
         }
         if (this.githubIconRect && pos[1] < LiteGraph.NODE_TITLE_HEIGHT) {
             const [x, y, w, h] = this.githubIconRect;
             const isOver = (pos[0] > x && pos[0] < x + w && pos[1] > y && pos[1] < y + h);
-            if(this.mouseOver_github_icon !== isOver) {
+            if (this.mouseOver_github_icon !== isOver) {
                 this.mouseOver_github_icon = isOver;
                 this.setDirtyCanvas(true, false);
             }
@@ -63,8 +63,8 @@ function addGitHubIcon(nodeType, url) {
     };
 
     const onMouseLeave = nodeType.prototype.onMouseLeave;
-    nodeType.prototype.onMouseLeave = function(e) {
-        if(this.mouseOver_github_icon) {
+    nodeType.prototype.onMouseLeave = function (e) {
+        if (this.mouseOver_github_icon) {
             this.mouseOver_github_icon = false;
             this.setDirtyCanvas(true, false);
         }
@@ -192,7 +192,7 @@ function setupGlobalMaskEditor() {
     const maskCanvas = document.getElementById("lmm-mask-canvas");
     const maskCtx = maskCanvas.getContext("2d");
     const brushCursor = document.getElementById("lmm-brush-cursor");
-    
+
     let editorState = { zoom: 1, panX: 0, panY: 0, isPanning: false, panStartX: 0, panStartY: 0 };
     let isDrawingMask = false;
     let currentImagePath = "";
@@ -201,9 +201,9 @@ function setupGlobalMaskEditor() {
         content.style.transform = `translate(${editorState.panX}px, ${editorState.panY}px) scale(${editorState.zoom})`;
     };
     const updateCursor = (e) => {
-        if (!e || editorState.isPanning) { 
-            viewport.style.cursor = editorState.isPanning ? "grabbing" : "default"; 
-            brushCursor.style.display = "none"; return; 
+        if (!e || editorState.isPanning) {
+            viewport.style.cursor = editorState.isPanning ? "grabbing" : "default";
+            brushCursor.style.display = "none"; return;
         }
         const rect = viewport.getBoundingClientRect();
         const x = e.clientX - rect.left;
@@ -223,31 +223,31 @@ function setupGlobalMaskEditor() {
         if (!isDrawingMask) return;
         e.preventDefault();
         const pos = getMousePos(e);
-        
+
         const size = document.getElementById("lmm-mask-brush-size").value;
         const blur = document.getElementById("lmm-mask-brush-blur").value;
 
         maskCtx.lineWidth = size;
-        maskCtx.lineCap = "round"; 
+        maskCtx.lineCap = "round";
         maskCtx.lineJoin = "round";
 
-        maskCtx.shadowBlur = blur; 
-        maskCtx.shadowColor = "white"; 
+        maskCtx.shadowBlur = blur;
+        maskCtx.shadowColor = "white";
 
         maskCtx.globalCompositeOperation = e.shiftKey ? "destination-out" : "source-over";
-        maskCtx.strokeStyle = "white"; 
+        maskCtx.strokeStyle = "white";
         maskCtx.fillStyle = "white";
-        
-        maskCtx.lineTo(pos.x, pos.y); 
+
+        maskCtx.lineTo(pos.x, pos.y);
         maskCtx.stroke();
-        
-        maskCtx.beginPath(); 
-        maskCtx.arc(pos.x, pos.y, maskCtx.lineWidth / 2, 0, Math.PI * 2); 
+
+        maskCtx.beginPath();
+        maskCtx.arc(pos.x, pos.y, maskCtx.lineWidth / 2, 0, Math.PI * 2);
         maskCtx.fill();
-        
-        maskCtx.beginPath(); 
+
+        maskCtx.beginPath();
         maskCtx.moveTo(pos.x, pos.y);
-        
+
         maskCtx.shadowBlur = 0;
     };
 
@@ -261,7 +261,7 @@ function setupGlobalMaskEditor() {
         editorState.zoom = newZoom;
         editorState.panX = (e.clientX - rect.left) - mouseXWorld * editorState.zoom;
         editorState.panY = (e.clientY - rect.top) - mouseYWorld * editorState.zoom;
-        updateTransform(); updateCursor(e); 
+        updateTransform(); updateCursor(e);
         document.getElementById("lmm-mask-info").textContent = `${maskCanvas.width} x ${maskCanvas.height} | ${Math.round(editorState.zoom * 100)}%`;
     });
     viewport.addEventListener("mousedown", (e) => {
@@ -278,32 +278,32 @@ function setupGlobalMaskEditor() {
     });
     window.addEventListener("mouseup", (e) => { editorState.isPanning = false; isDrawingMask = false; maskCtx.beginPath(); updateCursor(e); });
     viewport.addEventListener("contextmenu", (e) => e.preventDefault());
-    document.getElementById("lmm-mask-brush-size").addEventListener("input", (e) => updateCursor({clientX: -1000, clientY: -1000}));
-    
+    document.getElementById("lmm-mask-brush-size").addEventListener("input", (e) => updateCursor({ clientX: -1000, clientY: -1000 }));
+
     document.getElementById("lmm-mask-cancel").onclick = () => { overlay.style.display = "none"; };
-    
+
     document.getElementById("lmm-mask-save").onclick = async () => {
         const dataUrl = maskCanvas.toDataURL("image/png");
         const btn = document.getElementById("lmm-mask-save"); btn.textContent = "Saving..."; btn.disabled = true;
         try {
             await api.fetchApi("/local_image_gallery/save_mask", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ image_path: currentImagePath, mask_data: dataUrl }) });
-            if(lmm_mask_on_save_callback) lmm_mask_on_save_callback();
+            if (lmm_mask_on_save_callback) lmm_mask_on_save_callback();
             overlay.style.display = "none";
-        } catch(e) { alert("Failed: " + e); } finally { btn.textContent = "Save Mask"; btn.disabled = false; }
+        } catch (e) { alert("Failed: " + e); } finally { btn.textContent = "Save Mask"; btn.disabled = false; }
     };
-    
+
     document.getElementById("lmm-mask-clear").onclick = async () => {
-         maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
+        maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
     };
-    
+
     document.getElementById("lmm-mask-invert").onclick = () => {
         const imgData = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height);
         const d = imgData.data;
         for (let i = 0; i < d.length; i += 4) {
-            d[i+3] = 255 - d[i+3];
+            d[i + 3] = 255 - d[i + 3];
             d[i] = 255;
-            d[i+1] = 255;
-            d[i+2] = 255;
+            d[i + 1] = 255;
+            d[i + 2] = 255;
         }
         maskCtx.putImageData(imgData, 0, 0);
     };
@@ -328,13 +328,13 @@ function setupGlobalMaskEditor() {
     };
 
     displaySelect.addEventListener("change", updateMaskVisuals);
-    
+
     updateMaskVisuals();
 
     window.lmmOpenMaskEditor = async (path, onSaveCallback) => {
         currentImagePath = path;
         lmm_mask_on_save_callback = onSaveCallback;
-        
+
         const timestamp = new Date().getTime();
         const img = new Image();
         img.onload = async () => {
@@ -351,7 +351,7 @@ function setupGlobalMaskEditor() {
             document.getElementById("lmm-mask-info").textContent = `${img.width} x ${img.height} | ${Math.round(editorState.zoom * 100)}%`;
 
             try {
-                const res = await api.fetchApi("/local_image_gallery/get_mask_path", { method: "POST", headers: {"Content-Type": "application/json"}, body: JSON.stringify({ image_path: path }) });
+                const res = await api.fetchApi("/local_image_gallery/get_mask_path", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ image_path: path }) });
                 const data = await res.json();
 
                 maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
@@ -360,17 +360,17 @@ function setupGlobalMaskEditor() {
                     const mImg = new Image();
                     mImg.onload = () => {
                         maskCtx.drawImage(mImg, 0, 0);
-                        
-                        const iD = maskCtx.getImageData(0,0,maskCanvas.width, maskCanvas.height);
-                        for(let i=0; i<iD.data.length; i+=4) { 
+
+                        const iD = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height);
+                        for (let i = 0; i < iD.data.length; i += 4) {
                             const currentRed = iD.data[i];
-                            const currentAlpha = iD.data[i+3];
+                            const currentAlpha = iD.data[i + 3];
                             const finalAlpha = currentAlpha < 255 ? currentAlpha : currentRed;
 
                             iD.data[i] = 255;
-                            iD.data[i+1] = 255;
-                            iD.data[i+2] = 255;
-                            iD.data[i+3] = finalAlpha;
+                            iD.data[i + 1] = 255;
+                            iD.data[i + 2] = 255;
+                            iD.data[i + 3] = finalAlpha;
                         }
                         maskCtx.putImageData(iD, 0, 0);
                     };
@@ -381,7 +381,7 @@ function setupGlobalMaskEditor() {
                     tempCanvas.height = img.height;
                     const tempCtx = tempCanvas.getContext('2d');
                     tempCtx.drawImage(img, 0, 0);
-                    
+
                     const originalData = tempCtx.getImageData(0, 0, img.width, img.height).data;
                     const maskImageData = maskCtx.createImageData(maskCanvas.width, maskCanvas.height);
                     const maskPixels = maskImageData.data;
@@ -420,55 +420,55 @@ app.registerExtension({
             const onNodeCreated = nodeType.prototype.onNodeCreated;
             nodeType.prototype.onNodeCreated = function () {
                 const r = onNodeCreated?.apply(this, arguments);
-                
+
                 if (!this.properties || !this.properties.gallery_unique_id) {
                     if (!this.properties) { this.properties = {}; }
                     this.properties.gallery_unique_id = "gallery-" + Math.random().toString(36).substring(2, 11);
                 }
-                
+
                 const node_instance = this;
-                
+
                 const galleryIdWidget = this.addWidget(
                     "hidden_text",
                     "gallery_unique_id_widget",
                     this.properties.gallery_unique_id,
-                    () => {},
+                    () => { },
                     {}
                 );
                 galleryIdWidget.serializeValue = () => {
                     return node_instance.properties.gallery_unique_id;
                 };
-                galleryIdWidget.draw = function(ctx, node, widget_width, y, widget_height) {};
-                galleryIdWidget.computeSize = function(width) {
+                galleryIdWidget.draw = function (ctx, node, widget_width, y, widget_height) { };
+                galleryIdWidget.computeSize = function (width) {
                     return [0, 0];
                 };
-                
+
                 const selectionWidget = this.addWidget(
                     "hidden_text",
                     "selection",
                     this.properties.selection || "[]",
-                    () => {},
+                    () => { },
                     { multiline: true }
                 );
                 selectionWidget.serializeValue = () => {
                     return node_instance.properties["selection"] || "[]";
                 };
-                selectionWidget.draw = function(ctx, node, widget_width, y, widget_height) {};
-                selectionWidget.computeSize = function(width) { return [0, 0]; };
-                
+                selectionWidget.draw = function (ctx, node, widget_width, y, widget_height) { };
+                selectionWidget.computeSize = function (width) { return [0, 0]; };
+
                 const galleryContainer = document.createElement("div");
                 const uniqueId = `lmm-gallery-${Math.random().toString(36).substring(2, 9)}`;
                 galleryContainer.id = uniqueId;
 
                 galleryContainer.dataset.captureWheel = "true";
                 galleryContainer.addEventListener("wheel", (e) => {
-                     e.stopPropagation();
+                    e.stopPropagation();
                 });
-                
+
                 const folderSVG = `<svg viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><path d="M928 320H488L416 232c-15.1-18.9-38.3-29.9-63.1-29.9H128c-35.3 0-64 28.7-64 64v512c0 35.3 28.7 64 64 64h800c35.3 0 64-28.7 64-64V384c0-35.3-28.7-64-64-64z" fill="#F4D03F"></path></svg>`;
                 const videoSVG = `<svg viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><path d="M895.9 203.4H128.1c-35.3 0-64 28.7-64 64v489.2c0 35.3 28.7 64 64 64h767.8c35.3 0 64-28.7 64-64V267.4c0-35.3-28.7-64-64-64zM384 691.2V332.8L668.1 512 384 691.2z" fill="#FFD700"></path></svg>`;
                 const audioSVG = `<svg viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><path d="M768 256H256c-35.3 0-64 28.7-64 64v384c0 35.3 28.7 64 64 64h512c35.3 0 64-28.7 64-64V320c0-35.3-28.7-64-64-64zM512 665.6c-84.8 0-153.6-68.8-153.6-153.6S427.2 358.4 512 358.4s153.6 68.8 153.6 153.6-68.8 153.6-153.6 153.6z" fill="#A9DFBF"></path><path d="M512 409.6c-56.5 0-102.4 45.9-102.4 102.4s45.9 102.4 102.4 102.4 102.4-45.9 102.4-102.4-45.9-102.4-102.4-102.4z" fill="#A9DFBF"></path></svg>`;
-                
+
                 galleryContainer.innerHTML = `
                     <style>
                         #${uniqueId} .lmm-container-wrapper { width: 100%; font-family: sans-serif; color: var(--node-text-color); box-sizing: border-box; display: flex; flex-direction: column; height: 100%; }
@@ -721,15 +721,15 @@ app.registerExtension({
                 `;
                 this.addDOMWidget("local_image_gallery", "div", galleryContainer, {});
                 this.size = [800, 670];
-                
+
                 const cardholder = galleryContainer.querySelector(".lmm-cardholder");
                 const controls = galleryContainer.querySelector(".lmm-container-wrapper");
                 const placeholder = galleryContainer.querySelector(".lmm-gallery-placeholder");
-                
+
                 const breadcrumbContainer = controls.querySelector(".lmm-breadcrumb-container");
                 const breadcrumbEl = breadcrumbContainer.querySelector(".lmm-breadcrumb");
                 const pathInput = breadcrumbContainer.querySelector("input[type='text']");
-                
+
                 const pathPresets = controls.querySelector(".lmm-path-presets");
                 const addPathButton = controls.querySelector(".lmm-add-path-button");
                 const removePathButton = controls.querySelector(".lmm-remove-path-button");
@@ -763,9 +763,9 @@ app.registerExtension({
                         const scope = icon.dataset.scope;
                         if (activeScopes.has(scope)) activeScopes.delete(scope);
                         else activeScopes.add(scope);
-                    updateScopeDisplay();
-                    if (searchInput.value.trim()) saveStateAndReload(false);
-                });
+                        updateScopeDisplay();
+                        if (searchInput.value.trim()) saveStateAndReload(false);
+                    });
                 });
                 scopeAllToggle.addEventListener('click', () => {
                     const allScopes = ['current', 'input', 'output', 'saved'];
@@ -774,10 +774,10 @@ app.registerExtension({
                     } else {
                         allScopes.forEach(s => activeScopes.add(s));
                     }
-                        updateScopeDisplay();
-                        if (searchInput.value.trim()) saveStateAndReload(false);
-                    });
-                
+                    updateScopeDisplay();
+                    if (searchInput.value.trim()) saveStateAndReload(false);
+                });
+
                 // Scope icon tooltips — appended to body to avoid transform containment
                 const scopeTip = document.createElement('div');
                 Object.assign(scopeTip.style, {
@@ -808,7 +808,7 @@ app.registerExtension({
                             const show = paths.slice(0, 10);
                             detail = show.map(p => d(p)).join('\n');
                             if (paths.length > 10) detail += '\n' + d(`  \u2026and ${paths.length - 10} more`);
-                    }
+                        }
                         return detail + '\n' + t('Include saved paths in search scope');
                     }
                     if (el.classList.contains('lmm-scope-all')) return t('Toggle all search scopes');
@@ -832,7 +832,7 @@ app.registerExtension({
                     el.addEventListener('mouseenter', () => showScopeTip(el));
                     el.addEventListener('mouseleave', hideScopeTip);
                 });
-                
+
                 const clearSearchButton = controls.querySelector(".lmm-clear-search-button");
                 const tagEditor = controls.querySelector(".lmm-tag-editor");
                 const tagEditorInput = controls.querySelector(".lmm-tag-editor-input");
@@ -845,7 +845,7 @@ app.registerExtension({
                 const renameContainer = controls.querySelector(".lmm-rename-container");
                 const renameInput = controls.querySelector(".lmm-rename-input");
                 const renameBtn = controls.querySelector(".lmm-rename-btn");
-                
+
                 const renderBreadcrumb = (path) => {
                     breadcrumbEl.innerHTML = '';
                     if (!path || path === "Selected Items") {
@@ -855,13 +855,13 @@ app.registerExtension({
                         breadcrumbEl.appendChild(staticItem);
                         return;
                     }
-                    
+
                     path = path.replace(/\\/g, '/');
                     const parts = path.split('/').filter(p => p);
-                    
+
                     let builtPath = '';
                     const elements = [];
-                    
+
                     if (path.match(/^[a-zA-Z]:\//)) {
                         const drive = parts.shift();
                         builtPath = drive + '/';
@@ -878,52 +878,52 @@ app.registerExtension({
                         rootEl.dataset.path = builtPath;
                         elements.push(rootEl);
                     }
-                    
+
                     parts.forEach((part, index) => {
                         const separator = document.createElement('span');
                         separator.className = 'lmm-breadcrumb-separator';
                         separator.textContent = '>';
                         elements.push(separator);
-                        
+
                         let currentPartPath = builtPath + part + '/';
                         builtPath = currentPartPath;
-                        
+
                         const partEl = document.createElement('span');
                         partEl.className = 'lmm-breadcrumb-item';
                         partEl.textContent = part;
                         partEl.dataset.path = currentPartPath;
                         elements.push(partEl);
                     });
-                    
+
                     breadcrumbEl.append(...elements);
-                    
+
                     requestAnimationFrame(() => {
                         const containerWidth = breadcrumbEl.clientWidth;
                         let currentWidth = 0;
                         elements.forEach(el => currentWidth += el.offsetWidth);
-                        
+
                         if (currentWidth > containerWidth) {
                             const toRemove = [];
                             let removableWidth = currentWidth - containerWidth;
-                            
+
                             for (let i = elements.length - 3; i > 1; i--) {
-                               const el = elements[i];
+                                const el = elements[i];
                                 if (removableWidth > 0 && !(el.classList.contains('lmm-breadcrumb-item') && i === elements.length - 1)) {
-                                     removableWidth -= el.offsetWidth;
-                                     toRemove.push(el);
+                                    removableWidth -= el.offsetWidth;
+                                    toRemove.push(el);
                                 } else {
-                                     break;
+                                    break;
                                 }
                             }
-                            
+
                             if (toRemove.length > 0) {
                                 const ellipsis = document.createElement('span');
                                 ellipsis.className = 'lmm-breadcrumb-ellipsis';
                                 ellipsis.textContent = '...';
-                                if(elements[1]) { 
+                                if (elements[1]) {
                                     elements[1].insertAdjacentElement('afterend', ellipsis);
                                     const nextSeparator = elements[1].nextElementSibling.nextElementSibling;
-                                    if(nextSeparator && nextSeparator.classList.contains('lmm-breadcrumb-separator')) {
+                                    if (nextSeparator && nextSeparator.classList.contains('lmm-breadcrumb-separator')) {
                                         nextSeparator.remove();
                                     }
                                 }
@@ -931,9 +931,9 @@ app.registerExtension({
                             }
                         }
                     });
-                    
+
                 };
-                
+
                 breadcrumbEl.addEventListener('click', (e) => {
                     e.stopPropagation();
                     // If search is active, clicking breadcrumb cancels search
@@ -959,19 +959,19 @@ app.registerExtension({
                         pathInput.select();
                     }
                 });
-                
+
                 const switchToBreadcrumb = (forceReload = true) => {
                     pathInput.style.display = 'none';
                     breadcrumbEl.style.display = 'flex';
                     const currentPath = pathInput.value.trim();
-                    if(forceReload && lastKnownPath !== currentPath) {
-                       lastKnownPath = currentPath;
-                       saveStateAndReload(true);
+                    if (forceReload && lastKnownPath !== currentPath) {
+                        lastKnownPath = currentPath;
+                        saveStateAndReload(true);
                     } else {
-                       renderBreadcrumb(currentPath);
+                        renderBreadcrumb(currentPath);
                     }
                 };
-                
+
                 pathInput.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter') {
                         switchToBreadcrumb();
@@ -982,31 +982,31 @@ app.registerExtension({
                         e.preventDefault();
                     }
                 });
-                
+
                 pathInput.addEventListener('blur', () => {
-                   switchToBreadcrumb();
+                    switchToBreadcrumb();
                 });
-                
+
                 const updateBatchActionButtonsState = () => {
                     const hasSelection = selection.length > 0;
                     batchDeleteBtn.disabled = !hasSelection;
                     batchMoveBtn.disabled = !hasSelection;
                 };
-                
+
                 let isLoading = false, currentPage = 1, totalPages = 1, parentDir = null;
                 let selection = [];
                 let showSelectedMode = false;
                 let lastKnownPath = "";
                 let selectedCardsForEditing = new Set();
-                
-                let allItems = []; 
+
+                let allItems = [];
                 let layoutData = [];
                 const VIRTUAL_SCROLL_PADDING = 500;
                 let columnCount = 0;
                 let actualCardWidth = 0;
-                
+
                 const debounce = (func, delay) => { let timeoutId; return (...args) => { clearTimeout(timeoutId); timeoutId = setTimeout(() => func.apply(this, args), delay); }; };
-                
+
                 const calculateFullLayout = () => {
                     const minCardWidth = 150, gap = 5, containerWidth = cardholder.clientWidth;
                     if (containerWidth === 0 || allItems.length === 0) {
@@ -1014,9 +1014,9 @@ app.registerExtension({
                         layoutData = [];
                         return;
                     }
-                    
+
                     placeholder.style.display = 'none';
-                    
+
                     columnCount = Math.max(1, Math.floor(containerWidth / (minCardWidth + gap)));
                     const totalGapSpace = (columnCount - 1) * gap;
                     actualCardWidth = (containerWidth - totalGapSpace) / columnCount;
@@ -1035,16 +1035,16 @@ app.registerExtension({
                     }
 
                     layoutData = allItems.map((item, index) => {
-                        let aspectRatio = item.aspectRatio || 1.0; 
+                        let aspectRatio = item.aspectRatio || 1.0;
 
                         if (!isFinite(aspectRatio) || aspectRatio <= 0) {
                             aspectRatio = 1.0;
                         }
-                        
+
                         let imagePartHeight = actualCardWidth / aspectRatio;
-                        
+
                         if (item.type === 'image' || item.type === 'video') {
-                            imagePartHeight = Math.max(imagePartHeight, 100); 
+                            imagePartHeight = Math.max(imagePartHeight, 100);
 
                             const tags = item.tags.map(t => `<span class="lmm-tag">${t}</span>`).join('');
                             const workflowTextBadge = item.has_workflow ? `<div class="lmm-workflow-text-badge">Workflow</div>` : '';
@@ -1060,16 +1060,16 @@ app.registerExtension({
                                 </div>
                             `;
                             measuringDiv.innerHTML = infoPanelHTML;
-                            
+
                             const infoPanelHeight = measuringDiv.querySelector('.lmm-card-info-panel').offsetHeight + 2;
                             var cardHeight = imagePartHeight + infoPanelHeight;
                         } else {
-                            var cardHeight = 150; 
+                            var cardHeight = 150;
                         }
-                        
+
                         const minHeight = Math.min(...columnHeights);
                         const columnIndex = columnHeights.indexOf(minHeight);
-                        
+
                         const position = {
                             left: columnIndex * (actualCardWidth + gap),
                             top: minHeight,
@@ -1077,68 +1077,68 @@ app.registerExtension({
                             height: cardHeight,
                             columnIndex: columnIndex
                         };
-                        
+
                         columnHeights[columnIndex] += cardHeight + gap;
                         return position;
                     });
-                    
+
                     measuringDiv.innerHTML = "";
-                    
+
                     const totalHeight = Math.max(...columnHeights);
                     cardholder.style.height = `${totalHeight}px`;
-                    
+
                     updateVisibleItemsAndRender();
                 };
-                
+
                 const debouncedLayout = debounce(calculateFullLayout, 50);
-                
+
                 const updateVisibleItemsAndRender = () => {
                     const scrollTop = cardholder.scrollTop;
                     const viewHeight = cardholder.clientHeight;
                     const viewStart = scrollTop - VIRTUAL_SCROLL_PADDING;
                     const viewEnd = scrollTop + viewHeight + VIRTUAL_SCROLL_PADDING;
-                    
+
                     const newVisibleItems = [];
                     allItems.forEach((item, index) => {
                         const itemLayout = layoutData[index];
                         if (!itemLayout) return;
-                        
+
                         const itemTop = itemLayout.top;
                         const itemBottom = itemLayout.top + itemLayout.height;
-                        
+
                         if (itemBottom > viewStart && itemTop < viewEnd) {
                             newVisibleItems.push({ item, index, layout: itemLayout });
                         }
                     });
-                    
+
                     const existingCards = new Map(
                         Array.from(cardholder.querySelectorAll('.lmm-gallery-card')).map(card => [card.dataset.path, card])
                     );
                     const visiblePaths = new Set(newVisibleItems.map(vi => vi.item.path));
-                    
+
                     existingCards.forEach((card, path) => {
                         if (!visiblePaths.has(path)) {
                             card.remove();
                         }
                     });
-                    
+
                     newVisibleItems.forEach(({ item, index, layout }) => {
                         let card = existingCards.get(item.path);
                         if (!card) {
                             card = createCardElement(item);
                             cardholder.appendChild(card);
                         }
-                        
+
                         card.style.left = `${layout.left}px`;
                         card.style.top = `${layout.top}px`;
                         card.style.width = `${layout.width}px`;
-                        
+
                         if (selection.some(sel => sel.path === item.path)) {
                             card.classList.add('lmm-selected');
                         } else {
                             card.classList.remove('lmm-selected');
                         }
-                        
+
                         if (selectedCardsForEditing.has(item.path)) {
                             card.classList.add('lmm-edit-selected');
                         } else {
@@ -1147,10 +1147,10 @@ app.registerExtension({
                     });
                     renderSelectionBadges();
                 }
-                
+
                 new ResizeObserver(debouncedLayout).observe(cardholder);
                 new ResizeObserver(() => renderBreadcrumb(pathInput.value)).observe(breadcrumbContainer);
-                
+
                 async function setUiState(nodeId, state) {
                     const galleryId = this.properties.gallery_unique_id;
                     try {
@@ -1159,9 +1159,9 @@ app.registerExtension({
                             headers: { "Content-Type": "application/json" },
                             body: JSON.stringify({ node_id: nodeId, gallery_id: galleryId, state: state }),
                         });
-                    } catch(e) { console.error("LocalMediaManager: Failed to set UI state", e); }
+                    } catch (e) { console.error("LocalMediaManager: Failed to set UI state", e); }
                 }
-                
+
                 async function updateMetadata(path, { rating, tags }) {
                     try {
                         let payload = { path };
@@ -1170,18 +1170,18 @@ app.registerExtension({
                         await api.fetchApi("/local_image_gallery/update_metadata", {
                             method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
                         });
-                    } catch(e) { console.error("Failed to update metadata:", e); }
+                    } catch (e) { console.error("Failed to update metadata:", e); }
                 }
-                
+
                 async function savePaths() {
                     const paths = Array.from(pathPresets.options).map(o => o.value);
                     try {
                         await api.fetchApi("/local_image_gallery/save_paths", {
                             method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ paths }),
                         });
-                    } catch(e) { console.error("Failed to save paths:", e); }
+                    } catch (e) { console.error("Failed to save paths:", e); }
                 }
-                
+
                 async function loadAllTags() {
                     try {
                         const response = await api.fetchApi("/local_image_gallery/get_all_tags");
@@ -1199,21 +1199,21 @@ app.registerExtension({
                                 multiSelectTagDropdown.appendChild(label);
                             });
                         }
-                    } catch(e) { console.error("Failed to load all tags:", e); }
+                    } catch (e) { console.error("Failed to load all tags:", e); }
                 }
-                
+
                 function updateCardTagsUI(card) {
                     const tagListEl = card.querySelector('.lmm-tag-list');
                     if (!tagListEl) return;
-                    
+
                     const tags = card.dataset.tags ? card.dataset.tags.split(',').filter(Boolean) : [];
                     tagListEl.innerHTML = tags.map(t => `<span class="lmm-tag">${t}</span>`).join('');
                 }
-                
+
                 function renderSelectionBadges() {
                     galleryContainer.querySelectorAll('.lmm-selection-badge').forEach(badge => badge.remove());
                     const visibleSelectedCards = Array.from(cardholder.querySelectorAll('.lmm-gallery-card.lmm-selected'));
-                    
+
                     visibleSelectedCards.forEach(card => {
                         const path = card.dataset.path;
                         const index = selection.findIndex(item => item.path === path);
@@ -1222,23 +1222,23 @@ app.registerExtension({
                             badge.className = 'lmm-selection-badge';
                             badge.textContent = index;
                             const mediaWrapper = card.querySelector('.lmm-card-media-wrapper');
-                            if(mediaWrapper) mediaWrapper.appendChild(badge);
+                            if (mediaWrapper) mediaWrapper.appendChild(badge);
                         }
                     });
                 }
-                
+
                 function renderTagEditor() {
                     tagEditorList.innerHTML = "";
                     selectedCountEl.textContent = selectedCardsForEditing.size;
-                    
+
                     if (selectedCardsForEditing.size === 0) {
                         tagEditor.classList.remove("lmm-visible");
                         renameContainer.style.display = "none";
                         return;
                     }
-                    
+
                     const itemsToEdit = allItems.filter(item => selectedCardsForEditing.has(item.path));
-                    
+
                     if (itemsToEdit.length === 1) {
                         const singleItem = itemsToEdit[0];
                         const filename = singleItem.path.split(/[/\\]/).pop();
@@ -1247,10 +1247,10 @@ app.registerExtension({
                     } else {
                         renameContainer.style.display = "none";
                     }
-                    
+
                     const allTags = itemsToEdit.map(item => item.tags || []);
                     const commonTags = allTags.length > 0 ? allTags.reduce((acc, tags) => acc.filter(tag => tags.includes(tag))) : [];
-                    
+
                     commonTags.forEach(tag => {
                         const tagEl = document.createElement("span");
                         tagEl.className = "lmm-tag";
@@ -1260,23 +1260,23 @@ app.registerExtension({
                         removeEl.textContent = " ⓧ";
                         removeEl.onclick = async (e) => {
                             e.stopPropagation();
-                            
+
                             const updatePromises = itemsToEdit.map(async (item) => {
                                 const newTags = item.tags.filter(t => t !== tag);
-                                item.tags = newTags; 
+                                item.tags = newTags;
                                 await updateMetadata(item.path, { tags: newTags });
-                                
+
                                 const cardInDom = cardholder.querySelector(`.lmm-gallery-card[data-path="${CSS.escape(item.path)}"]`);
                                 if (cardInDom) {
                                     cardInDom.dataset.tags = newTags.join(',');
                                     updateCardTagsUI(cardInDom);
                                 }
                             });
-                            
+
                             await Promise.all(updatePromises);
                             await loadAllTags();
                             renderTagEditor();
-                            
+
                             if (tagFilterInput.value.trim()) {
                                 saveStateAndReload(false);
                             }
@@ -1284,10 +1284,10 @@ app.registerExtension({
                         tagEl.appendChild(removeEl);
                         tagEditorList.appendChild(tagEl);
                     });
-                    
+
                     tagEditor.classList.add("lmm-visible");
                 }
-                
+
                 const createCardElement = (item) => {
                     const card = document.createElement("div");
                     card.className = "lmm-gallery-card";
@@ -1296,7 +1296,7 @@ app.registerExtension({
                     card.dataset.tags = item.tags.join(',');
                     card.dataset.rating = item.rating;
                     card.title = item.name;
-                    
+
                     let mediaHTML = "";
                     if (item.type === 'dir') {
                         mediaHTML = `<div class="lmm-card-media-wrapper"><div class="lmm-folder-card"><div class="lmm-folder-icon">${folderSVG}</div><div class="lmm-folder-name">${item.name}</div></div></div>`;
@@ -1308,15 +1308,15 @@ app.registerExtension({
                         mediaHTML = `<div class="lmm-card-media-wrapper"><div class="lmm-audio-card"><div class="lmm-audio-icon">${audioSVG}</div><div class="lmm-audio-name">${item.name}</div></div></div>`;
                     }
                     card.innerHTML = mediaHTML;
-                    
+
                     if (item.type === 'image' || item.type === 'video') {
                         const infoPanel = document.createElement("div");
                         infoPanel.className = 'lmm-card-info-panel';
                         const stars = Array.from({ length: 5 }, (_, i) => `<span class="lmm-star" data-value="${i + 1}">☆</span>`).join('');
                         const tags = item.tags.map(t => `<span class="lmm-tag">${t}</span>`).join('');
-                        
+
                         const workflowTextBadge = item.has_workflow ? `<div class="lmm-workflow-text-badge" title="Click to load workflow">Workflow</div>` : '';
-                        
+
                         infoPanel.innerHTML = `
                             <div class="lmm-info-top-row">
                                 <div class="lmm-star-rating">${stars}</div>
@@ -1326,25 +1326,25 @@ app.registerExtension({
                             <div class="edit-tags-btn">✏️</div>
                         `;
                         card.appendChild(infoPanel);
-                        
+
                         if (item.has_workflow) {
                             const workflowTextEl = card.querySelector(".lmm-workflow-text-badge");
                             if (workflowTextEl) {
                                 workflowTextEl.addEventListener("click", async (e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
-                                    
+
                                     workflowTextEl.style.backgroundColor = '#4CAF50';
                                     workflowTextEl.style.color = 'white';
                                     workflowTextEl.textContent = "Loading...";
-                                    
+
                                     try {
                                         const response = await api.fetchApi(`/local_image_gallery/view?filepath=${encodeURIComponent(item.path)}`);
                                         const blob = await response.blob();
                                         const file = new File([blob], item.name, { type: blob.type });
-                                        
+
                                         app.handleFile(file);
-                                        
+
                                         setTimeout(() => {
                                             workflowTextEl.style.backgroundColor = 'rgba(0,0,0,0.4)';
                                             workflowTextEl.style.color = '#FFD700';
@@ -1359,7 +1359,7 @@ app.registerExtension({
                                 });
                             }
                         }
-                        
+
                         const editBtn = infoPanel.querySelector(".edit-tags-btn");
                         editBtn.addEventListener("click", (e) => {
                             e.stopPropagation();
@@ -1385,7 +1385,7 @@ app.registerExtension({
                             }
                             renderTagEditor();
                         });
-                        
+
                         const starRating = infoPanel.querySelector('.lmm-star-rating');
                         const starsList = starRating.querySelectorAll('.lmm-star');
                         const rating = parseInt(item.rating || 0);
@@ -1396,7 +1396,7 @@ app.registerExtension({
                             }
                         });
                     }
-                    
+
                     const img = card.querySelector("img");
                     if (img) {
                         img.onload = () => {
@@ -1410,28 +1410,28 @@ app.registerExtension({
                             }
                         };
                         img.onerror = () => {
-                             const itemIndex = allItems.findIndex(i => i.path === item.path);
-                             if (itemIndex > -1 && !allItems[itemIndex].aspectRatio) {
-                                allItems[itemIndex].aspectRatio = 1.0; 
+                            const itemIndex = allItems.findIndex(i => i.path === item.path);
+                            if (itemIndex > -1 && !allItems[itemIndex].aspectRatio) {
+                                allItems[itemIndex].aspectRatio = 1.0;
                                 debouncedLayout();
-                             }
+                            }
                         };
                     }
-                    
+
                     return card;
                 };
-                
+
                 const fetchImages = async (page = 1, append = false, forceRefresh = false) => {
                     if (isLoading) return;
                     isLoading = true;
                     updateShowSelectedButtonUI();
-                    
+
                     if (!append) {
                         cardholder.style.opacity = 0;
                         await new Promise(resolve => setTimeout(resolve, 200));
                         currentPage = 1;
                     }
-                    
+
                     if (showSelectedMode) {
                         if (selection.length === 0) {
                             placeholder.textContent = "No items selected.";
@@ -1442,24 +1442,24 @@ app.registerExtension({
                             isLoading = false;
                             return;
                         }
-                        
+
                         placeholder.textContent = "Loading selected items...";
                         placeholder.style.display = 'block';
                         try {
                             const response = await api.fetchApi("/local_image_gallery/get_selected_items", {
                                 method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ selection: selection }),
                             });
-                            
+
                             if (!response.ok) { const errorData = await response.json(); throw new Error(`HTTP error! status: ${response.status}, message: ${errorData.error}`); }
-                            
+
                             const api_data = await response.json();
                             allItems = api_data.items || [];
                             renderBreadcrumb("Selected Items");
                             breadcrumbEl.style.pointerEvents = "none";
                             upButton.disabled = true;
-                            
+
                             calculateFullLayout();
-                            
+
                         } catch (error) {
                             placeholder.textContent = `Error: ${error.message}`;
                             placeholder.style.color = 'red';
@@ -1469,9 +1469,9 @@ app.registerExtension({
                         }
                         return;
                     }
-                    
+
                     breadcrumbEl.style.pointerEvents = "auto";
-                    
+
                     const directory = pathInput.value;
                     const showImages = showImagesCheckbox.checked;
                     const showVideos = showVideosCheckbox.checked;
@@ -1507,20 +1507,20 @@ app.registerExtension({
                     }
                     let url = `/local_image_gallery/images?directory=${encodeURIComponent(directory)}&page=${page}&sort_by=${sortBy}&sort_order=${sortOrder}&show_images=${showImages}&show_videos=${showVideos}&show_audio=${showAudio}&filter_tag=${encodeURIComponent(filterTag)}&search_mode=${searchMode}&filter_mode=${filterMode}&force_refresh=${forceRefresh}&search_query=${encodeURIComponent(currentSearchQuery)}`;
                     currentSearchScopes.forEach(s => { url += `&search_scope=${encodeURIComponent(s)}`; });
-                    
+
                     if (selection.length > 0) {
                         selection.forEach(item => { url += `&selected_paths=${encodeURIComponent(item.path)}`; });
                     }
-                    
+
                     try {
                         const response = await api.fetchApi(url);
                         if (!response.ok) { const errorData = await response.json(); throw new Error(`HTTP error! status: ${response.status}, message: ${errorData.error}`); }
                         const api_data = await response.json();
                         const items = api_data.items || [];
-                        
+
                         totalPages = api_data.total_pages;
                         parentDir = api_data.parent_directory;
-                        
+
                         if (!api_data.is_global_search) {
                             pathInput.value = api_data.current_directory;
                             lastKnownPath = api_data.current_directory;
@@ -1567,13 +1567,13 @@ app.registerExtension({
                         } else {
                             placeholder.style.display = 'none';
                         }
-                        
+
                         calculateFullLayout();
-                        
+
                         cardholder.style.opacity = 1;
                         currentPage = page;
-                        
-                    } catch (error) { 
+
+                    } catch (error) {
                         placeholder.textContent = `Error: ${error.message}`;
                         placeholder.style.color = 'red';
                         placeholder.style.display = 'block';
@@ -1581,24 +1581,24 @@ app.registerExtension({
                         calculateFullLayout();
                         cardholder.style.opacity = 1;
                     }
-                    finally { 
+                    finally {
                         isLoading = false;
                     }
                 };
-                
+
                 cardholder.addEventListener('click', async (event) => {
                     const card = event.target.closest('.lmm-gallery-card');
                     if (!card) return;
-                    
+
                     if (event.target.classList.contains('lmm-star')) {
                         event.stopPropagation();
                         const newRating = parseInt(event.target.dataset.value);
                         const currentRating = parseInt(card.dataset.rating || 0);
                         const finalRating = newRating === currentRating ? 0 : newRating;
-                        
+
                         const itemData = allItems.find(i => i.path === card.dataset.path);
-                        if(itemData) itemData.rating = finalRating;
-                        
+                        if (itemData) itemData.rating = finalRating;
+
                         card.dataset.rating = finalRating;
                         await updateMetadata(card.dataset.path, { rating: finalRating });
                         const starRating = card.querySelector('.lmm-star-rating');
@@ -1629,10 +1629,10 @@ app.registerExtension({
                         pathPresets.selectedIndex = 0;
                         return;
                     }
-                    
+
                     if (['image', 'video', 'audio'].includes(type)) {
                         const selectionIndex = selection.findIndex(item => item.path === path);
-                        
+
                         if (event.ctrlKey) {
                             if (selectionIndex > -1) {
                                 selection.splice(selectionIndex, 1);
@@ -1651,33 +1651,33 @@ app.registerExtension({
                                 card.classList.add('lmm-selected');
                             }
                         }
-                        
+
                         renderSelectionBadges();
-                        
+
                         const selectionJson = JSON.stringify(selection);
                         this.setProperty("selection", selectionJson);
                         const widget = this.widgets.find(w => w.name === "selection");
                         if (widget) { widget.value = selectionJson; }
-                        
+
                         setUiState.call(this, this.id, { selection: selection });
                         updateBatchActionButtonsState();
-                        
+
                     }
                 });
-                
+
                 cardholder.addEventListener('dblclick', (event) => {
                     const card = event.target.closest('.lmm-gallery-card');
                     if (!card || !['image', 'video', 'audio'].includes(card.dataset.type)) return;
-                    
+
                     const currentMediaList = allItems.filter(item => ['image', 'video', 'audio'].includes(item.type));
                     const clickedPath = card.dataset.path;
                     const startIndex = currentMediaList.findIndex(item => item.path === clickedPath);
-                    
+
                     if (startIndex !== -1) {
                         showMediaAtIndex(startIndex, currentMediaList);
                     }
                 });
-                
+
                 const lightbox = document.getElementById('global-image-lightbox');
                 const lightboxImg = lightbox.querySelector("img");
                 const lightboxVideo = lightbox.querySelector("video");
@@ -1687,19 +1687,19 @@ app.registerExtension({
                 let scale = 1, panning = false, pointX = 0, pointY = 0, start = { x: 0, y: 0 };
                 let lightboxMediaList = [];
                 let lightboxCurrentIndex = -1;
-                
+
                 function setTransform() { lightboxImg.style.transform = `translate(${pointX}px, ${pointY}px) scale(${scale})`; }
                 function resetLightboxState() { scale = 1; pointX = 0; pointY = 0; setTransform(); }
-                
+
                 function showMediaAtIndex(index, mediaList) {
                     lightboxMediaList = mediaList;
                     if (index < 0 || index >= lightboxMediaList.length) return;
                     lightboxCurrentIndex = index;
                     const media = lightboxMediaList[index];
-                    
+
                     resetLightboxState();
                     lightbox.style.display = 'flex';
-                    
+
                     const dimensionsEl = lightbox.querySelector(".lightbox-dimensions");
                     lightboxImg.style.display = 'none';
                     lightboxVideo.style.display = 'none';
@@ -1707,7 +1707,7 @@ app.registerExtension({
                     dimensionsEl.style.display = 'none';
                     lightboxVideo.pause();
                     lightboxAudio.pause();
-                    
+
                     if (media.type === 'image') {
                         lightboxImg.style.display = 'block';
                         lightboxImg.src = `/local_image_gallery/view?filepath=${encodeURIComponent(media.path)}`;
@@ -1726,14 +1726,14 @@ app.registerExtension({
                         lightboxAudio.style.display = 'block';
                         lightboxAudio.src = `/local_image_gallery/view?filepath=${encodeURIComponent(media.path)}`;
                     }
-                    
+
                     prevButton.disabled = lightboxCurrentIndex === 0;
                     nextButton.disabled = lightboxCurrentIndex === lightboxMediaList.length - 1;
                 }
-                
+
                 prevButton.addEventListener('click', () => showMediaAtIndex(lightboxCurrentIndex - 1, lightboxMediaList));
                 nextButton.addEventListener('click', () => showMediaAtIndex(lightboxCurrentIndex + 1, lightboxMediaList));
-                
+
                 lightboxImg.addEventListener('mousedown', (e) => { e.preventDefault(); panning = true; lightboxImg.classList.add('panning'); start = { x: e.clientX - pointX, y: e.clientY - pointY }; });
                 window.addEventListener('mouseup', () => { panning = false; lightboxImg.classList.remove('panning'); });
                 window.addEventListener('mousemove', (e) => { if (!panning) return; e.preventDefault(); pointX = e.clientX - start.x; pointY = e.clientY - start.y; setTransform(); });
@@ -1741,7 +1741,7 @@ app.registerExtension({
                     if (lightboxImg.style.display !== 'block') return;
                     e.preventDefault(); const rect = lightboxImg.getBoundingClientRect(); const delta = -e.deltaY; const oldScale = scale; scale *= (delta > 0 ? 1.1 : 1 / 1.1); scale = Math.max(0.2, scale); pointX = (1 - scale / oldScale) * (e.clientX - rect.left) + pointX; pointY = (1 - scale / oldScale) * (e.clientY - rect.top) + pointY; setTransform();
                 });
-                
+
                 const closeLightbox = () => {
                     lightbox.style.display = 'none';
                     lightboxImg.src = "";
@@ -1750,18 +1750,18 @@ app.registerExtension({
                 };
                 lightbox.querySelector('.lightbox-close').addEventListener('click', closeLightbox);
                 lightbox.addEventListener('click', (e) => { if (e.target.classList.contains('lightbox-content')) closeLightbox(); });
-                
+
                 window.addEventListener('keydown', (e) => {
                     if (lightbox.style.display !== 'flex') return;
                     if (e.key === 'ArrowLeft') { e.preventDefault(); prevButton.click(); }
                     else if (e.key === 'ArrowRight') { e.preventDefault(); nextButton.click(); }
                     else if (e.key === 'Escape') { e.preventDefault(); closeLightbox(); }
                 });
-                
+
                 const saveCurrentControlsState = () => {
                     const sortBy = controls.querySelector(".lmm-sort-by");
                     const sortOrder = controls.querySelector(".lmm-sort-order");
-                    
+
                     const state = {
                         sort_by: sortBy.value,
                         sort_order: sortOrder.value,
@@ -1775,19 +1775,19 @@ app.registerExtension({
                     };
                     setUiState.call(this, this.id, state);
                 };
-                
+
                 const handleTagSelectionChange = () => {
                     const selectedTags = Array.from(multiSelectTagDropdown.querySelectorAll('input:checked')).map(cb => cb.value);
                     tagFilterInput.value = selectedTags.join(',');
                     lastFilteredTags = tagFilterInput.value.trim();
                     saveStateAndReload(false);
                 };
-                
+
                 const saveStateAndReload = (forceRefresh = false) => {
                     saveCurrentControlsState();
                     resetAndReload(forceRefresh);
                 };
-                
+
                 const resetAndReload = (forceRefresh = false) => { fetchImages.call(this, 1, false, forceRefresh); };
                 controls.querySelector('.lmm-refresh-button').onclick = () => saveStateAndReload(true);
                 let tagFilterDebounceTimer = null;
@@ -1822,7 +1822,7 @@ app.registerExtension({
                         document.execCommand('delete');
                     }
                 });
-                
+
                 tagEditorInput.addEventListener('keydown', async (e) => {
                     if (e.key === 'Enter' && selectedCardsForEditing.size > 0) {
                         e.preventDefault();
@@ -1834,7 +1834,7 @@ app.registerExtension({
                                 if (item && !item.tags.includes(newTag)) {
                                     item.tags.push(newTag);
                                     updatePromises.push(updateMetadata(path, { tags: item.tags }));
-                                    
+
                                     const cardInDom = cardholder.querySelector(`.lmm-gallery-card[data-path="${CSS.escape(path)}"]`);
                                     if (cardInDom) {
                                         cardInDom.dataset.tags = item.tags.join(',');
@@ -1842,7 +1842,7 @@ app.registerExtension({
                                     }
                                 }
                             });
-                            
+
                             await Promise.all(updatePromises);
                             await loadAllTags();
                             renderTagEditor();
@@ -1850,7 +1850,7 @@ app.registerExtension({
                         }
                     }
                 });
-                
+
                 controls.querySelectorAll('select:not(.lmm-path-presets)').forEach(select => { select.addEventListener('change', () => saveStateAndReload(false)); });
                 showImagesCheckbox.addEventListener('change', () => saveStateAndReload(false));
                 showVideosCheckbox.addEventListener('change', () => saveStateAndReload(false));
@@ -1895,7 +1895,7 @@ app.registerExtension({
                     saveStateAndReload(false);
                 });
                 // Scope change handling is done in the scopeIcons click listeners above
-                
+
                 addPathButton.addEventListener('click', () => {
                     const currentPath = pathInput.value.trim();
                     if (currentPath) {
@@ -1907,14 +1907,14 @@ app.registerExtension({
                         }
                     }
                 });
-                
+
                 removePathButton.addEventListener('click', () => {
                     if (pathPresets.selectedIndex > -1) {
                         pathPresets.remove(pathPresets.selectedIndex);
                         savePaths();
                     }
                 });
-                
+
                 pathPresets.addEventListener('change', () => {
                     if (pathPresets.value) {
                         pathInput.value = pathPresets.value;
@@ -1922,23 +1922,23 @@ app.registerExtension({
                         saveStateAndReload(true);
                     }
                 });
-                
+
                 const arrow = multiSelectTagContainer.querySelector('.lmm-multiselect-arrow');
                 multiSelectTagDisplay.addEventListener('click', () => {
                     const isVisible = multiSelectTagDropdown.style.display === 'block';
                     multiSelectTagDropdown.style.display = isVisible ? 'none' : 'block';
                     arrow.classList.toggle('open', !isVisible);
                 });
-                
+
                 document.addEventListener('click', (e) => {
                     if (!multiSelectTagContainer.contains(e.target)) {
                         multiSelectTagDropdown.style.display = 'none';
                         arrow.classList.remove('open');
                     }
                 });
-                
+
                 upButton.onclick = () => {
-                    if(parentDir){
+                    if (parentDir) {
                         pathInput.value = parentDir;
                         searchInput.value = '';
                         lastSearchedQuery = '';
@@ -1947,7 +1947,7 @@ app.registerExtension({
                         pathPresets.selectedIndex = 0;
                     }
                 };
-                
+
                 tagFilterModeBtn.addEventListener('click', () => {
                     if (tagFilterModeBtn.textContent === 'OR') {
                         tagFilterModeBtn.textContent = 'AND';
@@ -1958,7 +1958,7 @@ app.registerExtension({
                     }
                     saveStateAndReload(false);
                 });
-                
+
                 const updateShowSelectedButtonUI = () => {
                     if (showSelectedMode) {
                         showSelectedButton.classList.add('active');
@@ -1970,7 +1970,7 @@ app.registerExtension({
                         showSelectedButton.title = "Show all selected items across folders";
                     }
                 };
-                
+
                 showSelectedButton.addEventListener('click', () => {
                     showSelectedMode = !showSelectedMode;
                     if (!showSelectedMode) {
@@ -1978,14 +1978,14 @@ app.registerExtension({
                     }
                     saveStateAndReload(false);
                 });
-                
+
                 cardholder.onscroll = () => {
                     updateVisibleItemsAndRender();
-                    if (cardholder.scrollTop + cardholder.clientHeight >= cardholder.scrollHeight - 300 && !isLoading && currentPage < totalPages) { 
-                        fetchImages.call(this, currentPage + 1, true, false); 
-                    } 
+                    if (cardholder.scrollTop + cardholder.clientHeight >= cardholder.scrollHeight - 300 && !isLoading && currentPage < totalPages) {
+                        fetchImages.call(this, currentPage + 1, true, false);
+                    }
                 };
-                
+
                 const clearTagFilterButton = controls.querySelector(".lmm-clear-tag-filter-button");
                 clearTagFilterButton.addEventListener("click", () => {
                     tagFilterInput.value = "";
@@ -1995,7 +1995,7 @@ app.registerExtension({
                     checkboxes.forEach(cb => { cb.checked = false; });
                     saveStateAndReload(false);
                 });
-                
+
                 document.addEventListener("keydown", (e) => {
                     if (e.key === "Escape") {
                         if (selectedCardsForEditing.size > 0) {
@@ -2005,16 +2005,16 @@ app.registerExtension({
                         }
                     }
                 });
-                
+
                 batchSelectAllBtn.addEventListener('click', () => {
                     const allMediaItems = allItems.filter(card => card.type !== 'dir');
-                    
+
                     if (selection.length === allMediaItems.length) {
                         selection = [];
                     } else {
                         selection = allMediaItems.map(item => ({ path: item.path, type: item.type }));
                     }
-                    
+
                     cardholder.querySelectorAll('.lmm-gallery-card').forEach(card => {
                         if (selection.some(item => item.path === card.dataset.path)) {
                             card.classList.add('lmm-selected');
@@ -2022,18 +2022,18 @@ app.registerExtension({
                             card.classList.remove('lmm-selected');
                         }
                     });
-                    
+
                     renderSelectionBadges();
-                    
+
                     const selectionJson = JSON.stringify(selection);
                     node_instance.setProperty("selection", selectionJson);
                     const widget = node_instance.widgets.find(w => w.name === "selection");
                     if (widget) { widget.value = selectionJson; }
-                    
+
                     setUiState.call(node_instance, node_instance.id, { selection: selection });
                     updateBatchActionButtonsState();
                 });
-                
+
                 batchDeleteBtn.addEventListener('click', async () => {
                     if (selection.length === 0) return;
                     const filepaths = selection.map(item => item.path);
@@ -2048,14 +2048,14 @@ app.registerExtension({
                         } catch (e) { alert(`Failed to delete files: ${e}`); }
                     }
                 });
-                
+
                 batchMoveBtn.addEventListener('click', async () => {
                     if (selection.length === 0) return;
-                    
+
                     const source_paths = selection.map(item => item.path);
                     const presetOptions = Array.from(pathPresets.options).filter(o => o.value).map((o, i) => `${i + 1}: ${o.value}`).join('\n');
                     const destination_dir = prompt("Enter destination folder path, or a preset number:\n\n" + presetOptions);
-                    
+
                     if (destination_dir) {
                         let final_dest_dir = destination_dir.trim();
                         const presetIndex = parseInt(final_dest_dir, 10) - 1;
@@ -2063,7 +2063,7 @@ app.registerExtension({
                         if (!isNaN(presetIndex) && presetIndex >= 0 && presetIndex < presetValues.length) {
                             final_dest_dir = presetValues[presetIndex];
                         }
-                        
+
                         try {
                             const response = await api.fetchApi("/local_image_gallery/move_files", {
                                 method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ source_paths, destination_dir: final_dest_dir }),
@@ -2078,17 +2078,17 @@ app.registerExtension({
                         } catch (e) { alert(`Failed to move files: ${e}`); }
                     }
                 });
-                
+
                 const handleRename = async () => {
                     if (selectedCardsForEditing.size !== 1) return;
-                    
+
                     const old_path = selectedCardsForEditing.values().next().value;
                     const new_name = renameInput.value.trim();
-                    
+
                     if (!new_name || new_name === old_path.split(/[/\\]/).pop()) {
                         return;
                     }
-                    
+
                     try {
                         const response = await api.fetchApi("/local_image_gallery/rename_file", {
                             method: "POST",
@@ -2106,7 +2106,7 @@ app.registerExtension({
                                 if (widget) { widget.value = selectionJson; }
                                 setUiState.call(node_instance, node_instance.id, { selection: selection });
                             }
-                            
+
                             selectedCardsForEditing.clear();
                             renderTagEditor();
                             resetAndReload(true);
@@ -2117,7 +2117,7 @@ app.registerExtension({
                         alert(`Failed to rename file: ${e}`);
                     }
                 };
-                
+
                 renameBtn.addEventListener('click', handleRename);
                 renameInput.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter') {
@@ -2125,7 +2125,7 @@ app.registerExtension({
                         handleRename();
                     }
                 });
-                
+
                 const initializeNode = async () => {
                     try {
                         const galleryId = this.properties.gallery_unique_id;
@@ -2146,20 +2146,20 @@ app.registerExtension({
                             savedScopes.forEach(s => activeScopes.add(s));
                             updateScopeDisplay();
                             showSelectedMode = state.show_selected_mode || false;
-                            
+
                             selection = state.selection || [];
                             updateBatchActionButtonsState();
-                            
+
                             const selectionJson = JSON.stringify(selection);
                             this.setProperty("selection", selectionJson);
                             const widget = this.widgets.find(w => w.name === "selection");
                             if (widget) { widget.value = selectionJson; }
-                            
+
                             if (state.last_path) {
                                 pathInput.value = state.last_path;
                                 lastKnownPath = state.last_path;
                             }
-                            
+
                             switchToBreadcrumb(false);
                             resetAndReload(false);
                         }
@@ -2169,7 +2169,7 @@ app.registerExtension({
                         resetAndReload(false);
                     }
                 };
-                
+
                 const loadSavedPaths = async () => {
                     try {
                         const response = await api.fetchApi("/local_image_gallery/get_saved_paths");
@@ -2185,7 +2185,7 @@ app.registerExtension({
                         }
                     } catch (e) { console.error("Unable to load saved paths:", e); }
                 };
-                
+
                 const maskEditorBtn = controls.querySelector(".lmm-mask-editor-btn");
                 maskEditorBtn.addEventListener("click", () => {
                     if (selection.length !== 1 || selection[0].type !== 'image') {
@@ -2198,12 +2198,12 @@ app.registerExtension({
                         });
                     }
                 });
-                
+
                 setTimeout(() => initializeNode.call(this), 1);
                 loadSavedPaths();
                 loadAllTags();
-                
-                this.onResize = function(size) {
+
+                this.onResize = function (size) {
                     const minHeight = 470;
                     const minWidth = 800;
                     if (size[1] < minHeight) size[1] = minHeight;
@@ -2212,7 +2212,7 @@ app.registerExtension({
                     if (galleryContainer) {
                         let topOffset = galleryContainer.offsetTop;
 
-                        const approximateHeaderHeight = 120; 
+                        const approximateHeaderHeight = 120;
                         if (topOffset < 20) {
                             topOffset += approximateHeaderHeight;
                         }
@@ -2226,7 +2226,7 @@ app.registerExtension({
                     }
 
                     renderBreadcrumb(pathInput.value);
-                    debouncedLayout(); 
+                    debouncedLayout();
                 };
 
                 requestAnimationFrame(() => {
@@ -2234,7 +2234,7 @@ app.registerExtension({
                         this.onResize(this.size);
                     }
                 });
-                
+
                 return r;
             };
 

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -711,7 +711,7 @@ app.registerExtension({
                                 <button class="lmm-add-path-button" title="Add current path to presets">➕</button>
                                 <button class="lmm-remove-path-button" title="Remove selected preset">➖</button>
                             </div>
-                            <button class="lmm-refresh-button">🔄 Refresh</button>
+                            <button class="lmm-refresh-button" title="Force rescan of the current directory, bypassing cache. Use when files were added or removed outside the manager.">🔄 Refresh</button>
                         </div>
                         <div class="lmm-controls" style="gap: 5px;">
                             <label>Search:</label>
@@ -1237,7 +1237,7 @@ app.registerExtension({
                     const currentPath = pathInput.value.trim();
                     if (forceReload && lastKnownPath !== currentPath) {
                         lastKnownPath = currentPath;
-                        saveStateAndReload(true);
+                        saveStateAndReload(false);
                     } else {
                         renderBreadcrumb(currentPath);
                     }
@@ -1320,7 +1320,7 @@ app.registerExtension({
                         if (item.type === 'image' || item.type === 'video') {
                             imagePartHeight = Math.max(imagePartHeight, 100);
 
-                            const tags = item.tags.map(t => `<span class="lmm-tag">${t}</span>`).join('');
+                            const tags = item.tags.map(t => `<span class="lmm-tag" title="Click to filter by this tag">${t}</span>`).join('');
                             const workflowTextBadge = item.has_workflow ? `<div class="lmm-workflow-text-badge">Workflow</div>` : '';
                             const stars = Array.from({ length: 5 }, (_, i) => `<span class="lmm-star">☆</span>`).join('');
 
@@ -1493,7 +1493,7 @@ app.registerExtension({
                     if (!tagListEl) return;
 
                     const tags = card.dataset.tags ? card.dataset.tags.split(',').filter(Boolean) : [];
-                    tagListEl.innerHTML = tags.map(t => `<span class="lmm-tag">${t}</span>`).join('');
+                    tagListEl.innerHTML = tags.map(t => `<span class="lmm-tag" title="Click to filter by this tag">${t}</span>`).join('');
                 }
 
                 function renderSelectionBadges() {
@@ -1618,7 +1618,7 @@ app.registerExtension({
                         const infoPanel = document.createElement("div");
                         infoPanel.className = 'lmm-card-info-panel';
                         const stars = Array.from({ length: 5 }, (_, i) => `<span class="lmm-star" data-value="${i + 1}">☆</span>`).join('');
-                        const tags = item.tags.map(t => `<span class="lmm-tag">${t}</span>`).join('');
+                        const tags = item.tags.map(t => `<span class="lmm-tag" title="Click to filter by this tag">${t}</span>`).join('');
 
                         const workflowTextBadge = item.has_workflow ? `<div class="lmm-workflow-text-badge" title="Click to load workflow">Workflow</div>` : '';
 
@@ -1982,9 +1982,10 @@ app.registerExtension({
                         event.stopPropagation();
                         tagFilterInput.value = event.target.textContent;
                         lastFilteredTags = tagFilterInput.value.trim();
+                        syncTagDropdownToInput();
                         ['current', 'input', 'output', 'saved'].forEach(s => activeScopes.add(s));
                         updateScopeDisplay();
-                        resetAndReload(true);
+                        resetAndReload(false);
                         return;
                     }
 
@@ -1996,7 +1997,7 @@ app.registerExtension({
                         delete searchInput.dataset.savedValue;
                         lastSearchedQuery = '';
                         tagFilterInput.value = "";
-                        resetAndReload(true);
+                        resetAndReload(false);
                         pathPresets.selectedIndex = 0;
                         return;
                     }
@@ -2129,6 +2130,19 @@ app.registerExtension({
                     else if (e.key === 'Escape') { e.preventDefault(); closeLightbox(); }
                 });
 
+                const syncTagDropdownToInput = () => {
+                    const inputTags = new Set(tagFilterInput.value.split(',').map(t => t.trim().toLowerCase()).filter(Boolean));
+                    const checkboxes = multiSelectTagDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all)');
+                    checkboxes.forEach(cb => { cb.checked = inputTags.has(cb.value.toLowerCase()); });
+                    const tagAllCb = multiSelectTagDropdown.querySelector('.lmm-select-all');
+                    if (tagAllCb) {
+                        const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+                        const noneChecked = Array.from(checkboxes).every(cb => !cb.checked);
+                        tagAllCb.checked = allChecked;
+                        tagAllCb.indeterminate = !allChecked && !noneChecked;
+                    }
+                };
+
                 const saveCurrentControlsState = () => {
                     const sortBy = controls.querySelector(".lmm-sort-by");
                     const sortOrder = controls.querySelector(".lmm-sort-order");
@@ -2185,6 +2199,7 @@ app.registerExtension({
                         const t = tagFilterInput.value.trim();
                         if (t !== lastFilteredTags) {
                             lastFilteredTags = t;
+                            syncTagDropdownToInput();
                             saveStateAndReload(false);
                         }
                     }, 1000);
@@ -2194,6 +2209,7 @@ app.registerExtension({
                     const t = tagFilterInput.value.trim();
                     if (t !== lastFilteredTags) {
                         lastFilteredTags = t;
+                        syncTagDropdownToInput();
                         saveStateAndReload(false);
                     }
                 });
@@ -2201,6 +2217,7 @@ app.registerExtension({
                     if (e.key === 'Enter') {
                         clearTimeout(tagFilterDebounceTimer);
                         lastFilteredTags = tagFilterInput.value.trim();
+                        syncTagDropdownToInput();
                         saveStateAndReload(false);
                     } else if (e.key === 'Escape' && tagFilterInput.value) {
                         e.preventDefault();
@@ -2362,7 +2379,7 @@ app.registerExtension({
                     if (pathPresets.value) {
                         pathInput.value = pathPresets.value;
                         lastKnownPath = pathInput.value;
-                        saveStateAndReload(true);
+                        saveStateAndReload(false);
                     }
                 });
 
@@ -2391,7 +2408,7 @@ app.registerExtension({
                         delete searchInput.dataset.savedValue;
                         lastSearchedQuery = '';
                         tagFilterInput.value = "";
-                        resetAndReload(true);
+                        resetAndReload(false);
                         pathPresets.selectedIndex = 0;
                     }
                 };
@@ -2450,8 +2467,7 @@ app.registerExtension({
                     tagFilterInput.value = "";
                     lastFilteredTags = '';
                     clearTimeout(tagFilterDebounceTimer);
-                    const checkboxes = multiSelectTagDropdown.querySelectorAll('input[type="checkbox"]');
-                    checkboxes.forEach(cb => { cb.checked = false; });
+                    syncTagDropdownToInput();
                     saveStateAndReload(false);
                 });
 

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -1349,17 +1349,36 @@ app.registerExtension({
                     actualCardWidth = (containerWidth - totalGapSpace) / columnCount;
                     const columnHeights = new Array(columnCount).fill(0);
 
+                    // Measure info panel base height once (1 reflow), then estimate tag rows with math.
+                    // This avoids N reflows from the old measuringDiv-per-item approach.
                     const measuringDivId = `lmm-measuring-div-${uniqueId}`;
                     let measuringDiv = galleryContainer.querySelector(`#${measuringDivId}`);
                     if (!measuringDiv) {
                         measuringDiv = document.createElement("div");
                         measuringDiv.id = measuringDivId;
-                        measuringDiv.style.position = "absolute";
-                        measuringDiv.style.left = "-9999px";
-                        measuringDiv.style.visibility = "hidden";
-                        measuringDiv.style.pointerEvents = "none";
+                        measuringDiv.style.cssText = "position:absolute;left:-9999px;visibility:hidden;pointer-events:none";
                         galleryContainer.appendChild(measuringDiv);
                     }
+                    const sampleStars = Array.from({ length: 5 }, () => '<span class="lmm-star">☆</span>').join('');
+                    measuringDiv.innerHTML = `<div class="lmm-card-info-panel" style="width:${actualCardWidth}px">
+                        <div class="lmm-info-top-row"><div class="lmm-star-rating">${sampleStars}</div></div>
+                        <div class="lmm-card-actions"><div class="lmm-card-actions-right">
+                            <div class="copy-path-btn">📁</div><div class="edit-tags-btn">✏️</div><div class="open-media-btn">🔎</div>
+                        </div></div>
+                        <div class="lmm-tag-list"></div>
+                    </div>`;
+                    const INFO_PANEL_BASE = measuringDiv.querySelector('.lmm-card-info-panel').offsetHeight + 2;
+                    measuringDiv.innerHTML = "";
+                    const TAG_ROW_HEIGHT = 17; // 14px tag + 3px gap
+                    const AVG_TAG_WIDTH = 50;  // approximate px per tag (font-size 10px + padding)
+
+                    const estimateInfoPanelHeight = (item) => {
+                        if (!item.tags || item.tags.length === 0) return INFO_PANEL_BASE;
+                        const availableWidth = actualCardWidth - 4;
+                        const tagsPerRow = Math.max(1, Math.floor(availableWidth / AVG_TAG_WIDTH));
+                        const tagRows = Math.ceil(item.tags.length / tagsPerRow);
+                        return INFO_PANEL_BASE + tagRows * TAG_ROW_HEIGHT;
+                    };
 
                     layoutData = allItems.map((item, index) => {
                         let aspectRatio = item.aspectRatio || 1.0;
@@ -1369,31 +1388,13 @@ app.registerExtension({
                         }
 
                         const cardBorder = 6; // 3px border each side (box-sizing: border-box)
-                        let imagePartHeight = (actualCardWidth - cardBorder) / aspectRatio;
-
+                        let cardHeight;
 
                         if (item.type === 'image' || item.type === 'video') {
-                            imagePartHeight = Math.max(imagePartHeight, 100);
-
-                            const tags = item.tags.map(t => `<span class="lmm-tag" title="Click to filter by this tag">${t}</span>`).join('');
-                            const workflowTextBadge = item.has_workflow ? `<div class="lmm-workflow-text-badge">Workflow</div>` : '';
-                            const stars = Array.from({ length: 5 }, (_, i) => `<span class="lmm-star">☆</span>`).join('');
-
-                            const infoPanelHTML = `
-                                <div class="lmm-card-info-panel" style="width: ${actualCardWidth}px;">
-                                    <div class="lmm-info-top-row">
-                                        <div class="lmm-star-rating">${stars}</div>
-                                        ${workflowTextBadge}
-                                    </div>
-                                    <div class="lmm-tag-list">${tags}</div>
-                                </div>
-                            `;
-                            measuringDiv.innerHTML = infoPanelHTML;
-
-                            const infoPanelHeight = measuringDiv.querySelector('.lmm-card-info-panel').offsetHeight + 2;
-                            var cardHeight = imagePartHeight + infoPanelHeight + cardBorder;
+                            const imagePartHeight = Math.max((actualCardWidth - cardBorder) / aspectRatio, 100);
+                            cardHeight = imagePartHeight + estimateInfoPanelHeight(item) + cardBorder;
                         } else {
-                            var cardHeight = 150;
+                            cardHeight = 150;
                         }
 
                         const minHeight = Math.min(...columnHeights);
@@ -1410,8 +1411,6 @@ app.registerExtension({
                         columnHeights[columnIndex] += cardHeight + gap;
                         return position;
                     });
-
-                    measuringDiv.innerHTML = "";
 
                     const totalHeight = Math.max(...columnHeights);
                     cardholder.style.height = `${totalHeight}px`;

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -590,11 +590,12 @@ app.registerExtension({
                             background-color: rgba(80,80,80,0.6);
                         }
                         
-                        #${uniqueId} .edit-tags-btn, #${uniqueId} .open-media-btn { position: absolute; bottom: 2px; width: 22px; height: 22px; background-color: rgba(0,0,0,0.5); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; transition: background-color 0.2s; opacity: 0; cursor: pointer; }
+                        #${uniqueId} .edit-tags-btn, #${uniqueId} .open-media-btn, #${uniqueId} .copy-path-btn { position: absolute; bottom: 2px; width: 22px; height: 22px; background-color: rgba(0,0,0,0.5); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; transition: background-color 0.2s; opacity: 0; cursor: pointer; }
                         #${uniqueId} .open-media-btn { right: 2px; }
                         #${uniqueId} .edit-tags-btn { right: 28px; }
-                        #${uniqueId} .lmm-gallery-card:hover .edit-tags-btn, #${uniqueId} .lmm-gallery-card:hover .open-media-btn { opacity: 1; }
-                        #${uniqueId} .edit-tags-btn:hover, #${uniqueId} .open-media-btn:hover { background-color: rgba(0,0,0,0.8); }
+                        #${uniqueId} .copy-path-btn { right: 54px; }
+                        #${uniqueId} .lmm-gallery-card:hover .edit-tags-btn, #${uniqueId} .lmm-gallery-card:hover .open-media-btn, #${uniqueId} .lmm-gallery-card:hover .copy-path-btn { opacity: 1; }
+                        #${uniqueId} .edit-tags-btn:hover, #${uniqueId} .open-media-btn:hover, #${uniqueId} .copy-path-btn:hover { background-color: rgba(0,0,0,0.8); }
                         #${uniqueId} .lmm-star-rating { font-size: 16px; cursor: pointer; color: #555; }
                         #${uniqueId} .lmm-star-rating .lmm-star:hover { color: #FFD700 !important; }
                         #${uniqueId} .lmm-star-rating .lmm-star.lmm-rated { color: #FFC700; }
@@ -609,7 +610,8 @@ app.registerExtension({
                         #${uniqueId} .lmm-tag-editor-list { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
                         #${uniqueId} .lmm-tag-editor-list .lmm-tag .lmm-remove-tag { margin-left: 4px; color: #fdd; cursor: pointer; font-weight: bold; }
                         #${uniqueId} .lmm-show-selected-btn.active { background-color: #4A90E2; color: white; border-color: #4A90E2; }
-                        #${uniqueId} .lmm-recursive-btn.active { background-color: #7C3AED; color: white; border-color: #7C3AED; }
+                        #${uniqueId} .lmm-recursive-btn { transition: opacity 0.15s; }
+                        #${uniqueId} .lmm-recursive-btn.inactive { opacity: 0.2; }
                         #${uniqueId} .lmm-tag-filter-wrapper { display: flex; flex-grow: 1; position: relative; align-items: center; }
                         #${uniqueId} .lmm-tag-filter-wrapper input { flex-grow: 1; transition: box-shadow 0.2s; }
                         #${uniqueId} .lmm-multiselect-tag { position: relative; flex-grow: 1; }
@@ -637,6 +639,19 @@ app.registerExtension({
                             display: block; padding: 0px 0px; cursor: pointer; font-size: 12px; color: #ccc;
                         }
                         #${uniqueId} .lmm-multiselect-tag-dropdown label:hover { background-color: #444; }
+                        #${uniqueId} .lmm-multiselect-rating { position: relative; }
+                        #${uniqueId} .lmm-multiselect-rating-display {
+                            background-color: #333; color: #ccc; border: 1px solid #555; border-radius: 4px; padding: 4px 20px 4px 4px; font-size: 10px;
+                            height: 23px; cursor: pointer; display: flex; align-items: center; gap: 4px; white-space: nowrap;
+                        }
+                        #${uniqueId} .lmm-multiselect-rating-dropdown {
+                            display: none; position: absolute; top: 100%; left: 0; min-width: 100%; background-color: #222;
+                            border: 1px solid #555; border-top: none; max-height: 200px; overflow-y: auto; z-index: 10;
+                        }
+                        #${uniqueId} .lmm-multiselect-rating-dropdown label {
+                            display: block; padding: 0px 2px; cursor: pointer; font-size: 12px; color: #ccc; white-space: nowrap;
+                        }
+                        #${uniqueId} .lmm-multiselect-rating-dropdown label:hover { background-color: #444; }
                         #${uniqueId} .lmm-tag-filter-mode-btn {
                             padding: 4px 8px; background-color: #555; color: #fff; border: 1px solid #666;
                             border-radius: 4px; cursor: pointer; flex-shrink: 0;
@@ -672,6 +687,9 @@ app.registerExtension({
                         #${uniqueId} .lmm-search-wrapper input:not(:placeholder-shown) + .lmm-clear-search-button { display: block; }
                         #${uniqueId} .lmm-search-wrapper input:not(:placeholder-shown) + .lmm-clear-search-button + .lmm-search-info-button { display: none; }
                         #${uniqueId} .lmm-search-info-button { position: absolute; right: 0px; color: #777; cursor: pointer; font-size: 13px; padding: 2px 4px; user-select: none; }
+                        #${uniqueId} .lmm-type-icons { display: flex; gap: 2px; font-size: 14px; line-height: 1; align-items: center; }
+                        #${uniqueId} .lmm-type-icons span { cursor: pointer; transition: opacity 0.15s; user-select: none; }
+                        #${uniqueId} .lmm-type-icons span.inactive { opacity: 0.2; }
                         #${uniqueId} .lmm-search-scope-container { flex-shrink: 0; }
                         #${uniqueId} .lmm-scope-icons { display: flex; gap: 2px; font-size: 14px; line-height: 1; align-items: center; }
                         #${uniqueId} .lmm-scope-icons span { cursor: pointer; transition: opacity 0.15s; user-select: none; }
@@ -729,17 +747,18 @@ app.registerExtension({
                             </div>
                         </div>
                         <div class="lmm-controls" style="gap: 5px;">
-                            <label>Sort by:</label> <select class="lmm-sort-by"> <option value="name">Name</option> <option value="date">Date</option> <option value="rating">Rating</option> </select>
-                            <label>Order:</label> <select class="lmm-sort-order"> <option value="asc">Ascending</option> <option value="desc">Descending</option> </select>
-                            <label>Rating:</label>
-                            <select class="lmm-min-rating"><option value="0">0</option><option value="1">1★</option><option value="2">2★</option><option value="3">3★</option><option value="4">4★</option><option value="5">5★</option></select>
-                            <span style="color: #888;">–</span>
-                            <select class="lmm-max-rating"><option value="0">0</option><option value="1">1★</option><option value="2">2★</option><option value="3">3★</option><option value="4">4★</option><option value="5" selected>5★</option></select>
+                            <label>Sort</label> <select class="lmm-sort-by"> <option value="name">Name</option> <option value="date">Date</option> <option value="rating">Rating</option> </select>
+                            <select class="lmm-sort-order"> <option value="asc">Ascending</option> <option value="desc">Descending</option> </select>
+                            <div class="lmm-multiselect-rating">
+                                <div class="lmm-multiselect-rating-display">
+                                    <span class="lmm-rating-display-text">0★ 1★ 2★ 3★ 4★ 5★</span>
+                                    <span class="lmm-multiselect-arrow">▼</span>
+                                </div>
+                                <div class="lmm-multiselect-rating-dropdown"></div>
+                            </div>
                             <div style="margin-left: auto; display: flex; align-items: center; gap: 5px;">
-                                <label>Images:</label> <input type="checkbox" class="lmm-show-images" checked>
-                                <label>Videos:</label> <input type="checkbox" class="lmm-show-videos">
-                                <label>Audio:</label> <input type="checkbox" class="lmm-show-audio">
-                                <button class="lmm-recursive-btn" title="Show rated/tagged items from all subdirectories recursively">🔍 Recursive</button>
+                                <span class="lmm-type-icons"><span data-type="images" title="Show images">🖼️</span><span data-type="videos" title="Show videos">🎬</span><span data-type="audio" class="inactive" title="Show audio">🔊</span></span>
+                                <button class="lmm-recursive-btn inactive" title="Show items from all subdirectories recursively">📂 Recursive</button>
                                 <button class="lmm-show-selected-btn" title="Show all selected items across folders">Show Selected</button>
                                 <button class="lmm-batch-action-btn lmm-batch-select-all-btn" title="Select All Files in Current View">Select All</button>
                             </div>
@@ -775,17 +794,25 @@ app.registerExtension({
                 const addPathButton = controls.querySelector(".lmm-add-path-button");
                 const removePathButton = controls.querySelector(".lmm-remove-path-button");
                 const upButton = controls.querySelector(".lmm-up-button");
-                const showImagesCheckbox = controls.querySelector(".lmm-show-images");
-                const showVideosCheckbox = controls.querySelector(".lmm-show-videos");
-                const showAudioCheckbox = controls.querySelector(".lmm-show-audio");
+                const typeIcons = controls.querySelectorAll(".lmm-type-icons span[data-type]");
+                const isTypeActive = (type) => !controls.querySelector(`.lmm-type-icons span[data-type="${type}"]`).classList.contains('inactive');
+                typeIcons.forEach(icon => {
+                    icon.addEventListener('click', () => {
+                        icon.classList.toggle('inactive');
+                        saveStateAndReload(false);
+                    });
+                });
                 const tagFilterInput = controls.querySelector(".lmm-tag-filter-input");
                 const tagFilterModeBtn = controls.querySelector(".lmm-tag-filter-mode-btn");
                 const combineModeBtn = controls.querySelector(".lmm-combine-mode-btn");
                 const multiSelectTagContainer = controls.querySelector(".lmm-multiselect-tag");
                 const multiSelectTagDisplay = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-display");
                 const multiSelectTagDropdown = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-dropdown");
-                const minRatingSelect = controls.querySelector(".lmm-min-rating");
-                const maxRatingSelect = controls.querySelector(".lmm-max-rating");
+                const ratingContainer = controls.querySelector(".lmm-multiselect-rating");
+                const ratingDisplay = ratingContainer.querySelector(".lmm-multiselect-rating-display");
+                const ratingDropdown = ratingContainer.querySelector(".lmm-multiselect-rating-dropdown");
+                const ratingDisplayText = ratingContainer.querySelector(".lmm-rating-display-text");
+                const ratingArrow = ratingContainer.querySelector(".lmm-multiselect-arrow");
                 const recursiveBtn = controls.querySelector(".lmm-recursive-btn");
                 const searchInput = controls.querySelector(".lmm-search-input");
                 const searchStatus = controls.querySelector(".lmm-search-status");
@@ -1434,6 +1461,18 @@ app.registerExtension({
                     try {
                         const data = await fetchTagsCached();
                         multiSelectTagDropdown.innerHTML = '';
+                        const allLabel = document.createElement('label');
+                        allLabel.style.borderBottom = '1px solid #444';
+                        const allCb = document.createElement('input');
+                        allCb.type = 'checkbox';
+                        allCb.className = 'lmm-select-all';
+                        allCb.addEventListener('change', () => {
+                            multiSelectTagDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all)').forEach(cb => { cb.checked = allCb.checked; });
+                            handleTagSelectionChange();
+                        });
+                        allLabel.appendChild(allCb);
+                        allLabel.appendChild(document.createTextNode(' All'));
+                        multiSelectTagDropdown.appendChild(allLabel);
                         if (data.tags) {
                             data.tags.forEach(tag => {
                                 const label = document.createElement('label');
@@ -1589,8 +1628,9 @@ app.registerExtension({
                                 ${workflowTextBadge}
                             </div>
                             <div class="lmm-tag-list">${tags}</div>
-                            <div class="open-media-btn">🔎</div>
-                            <div class="edit-tags-btn">✏️</div>
+                            <div class="copy-path-btn" title="Copy file path">📁</div>
+                            <div class="open-media-btn" title="Open in lightbox">🔎</div>
+                            <div class="edit-tags-btn" title="Edit tags">✏️</div>
                         `;
                         card.appendChild(infoPanel);
 
@@ -1659,6 +1699,28 @@ app.registerExtension({
                             const currentMediaList = allItems.filter(i => ['image', 'video', 'audio'].includes(i.type));
                             const idx = currentMediaList.findIndex(i => i.path === item.path);
                             if (idx !== -1) showMediaAtIndex(idx, currentMediaList);
+                        });
+
+                        const copyPathBtn = infoPanel.querySelector(".copy-path-btn");
+                        copyPathBtn.addEventListener("click", (e) => {
+                            e.stopPropagation();
+                            const doCopy = (text) => {
+                                if (navigator.clipboard?.writeText) {
+                                    return navigator.clipboard.writeText(text);
+                                }
+                                const ta = document.createElement('textarea');
+                                ta.value = text;
+                                ta.style.cssText = 'position:fixed;opacity:0';
+                                document.body.appendChild(ta);
+                                ta.select();
+                                document.execCommand('copy');
+                                ta.remove();
+                                return Promise.resolve();
+                            };
+                            doCopy(item.path).then(() => {
+                                copyPathBtn.textContent = '✓';
+                                setTimeout(() => { copyPathBtn.textContent = '📁'; }, 1000);
+                            }).catch(() => {});
                         });
 
                         const starRating = infoPanel.querySelector('.lmm-star-rating');
@@ -1751,9 +1813,9 @@ app.registerExtension({
                     breadcrumbEl.style.pointerEvents = "auto";
 
                     const directory = pathInput.value;
-                    const showImages = showImagesCheckbox.checked;
-                    const showVideos = showVideosCheckbox.checked;
-                    const showAudio = showAudioCheckbox.checked;
+                    const showImages = isTypeActive('images');
+                    const showVideos = isTypeActive('videos');
+                    const showAudio = isTypeActive('audio');
                     const filterTag = tagFilterInput.value;
                     const currentSearchQuery = searchInput.value.trim();
                     const currentSearchScopes = getSelectedScopes();
@@ -1787,7 +1849,8 @@ app.registerExtension({
                     }
                     let url = `/local_image_gallery/images?directory=${encodeURIComponent(directory)}&page=${page}&sort_by=${sortBy}&sort_order=${sortOrder}&show_images=${showImages}&show_videos=${showVideos}&show_audio=${showAudio}&filter_tag=${encodeURIComponent(filterTag)}&search_mode=${searchMode}&filter_mode=${filterMode}&combine_mode=${combineMode}&force_refresh=${forceRefresh}&search_query=${encodeURIComponent(currentSearchQuery)}`;
                     currentSearchScopes.forEach(s => { url += `&search_scope=${encodeURIComponent(s)}`; });
-                    url += `&min_rating=${minRatingSelect.value}&max_rating=${maxRatingSelect.value}&recursive=${recursiveMode}`;
+                    const selectedRatings = Array.from(ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all):checked')).map(cb => cb.value);
+                    url += `&filter_ratings=${selectedRatings.join(',')}&recursive=${recursiveMode}`;
 
                     if (selection.length > 0) {
                         selection.forEach(item => { url += `&selected_paths=${encodeURIComponent(item.path)}`; });
@@ -1869,7 +1932,7 @@ app.registerExtension({
                         }
 
                         if (allItems.length === 0) {
-                            placeholder.textContent = currentSearchQuery ? `No files matching "${currentSearchQuery}".` : (api_data.is_global_search ? 'No items found for this tag.' : 'The folder is empty.');
+                            placeholder.textContent = currentSearchQuery ? `No files matching "${currentSearchQuery}".` : (recursiveMode ? 'No media files found in subdirectories.' : (api_data.is_global_search ? 'No items found for this tag.' : 'The folder is empty.'));
                             placeholder.style.display = 'block';
                         } else {
                             placeholder.style.display = 'none';
@@ -2071,28 +2134,39 @@ app.registerExtension({
                     const sortOrder = controls.querySelector(".lmm-sort-order");
 
                     const state = {
+                        last_path: lastKnownPath,
                         sort_by: sortBy.value,
                         sort_order: sortOrder.value,
-                        show_images: showImagesCheckbox.checked,
-                        show_videos: showVideosCheckbox.checked,
-                        show_audio: showAudioCheckbox.checked,
+                        show_images: isTypeActive('images'),
+                        show_videos: isTypeActive('videos'),
+                        show_audio: isTypeActive('audio'),
                         filter_tag: tagFilterInput.value,
                         filter_mode: tagFilterModeBtn.textContent,
                         combine_mode: combineModeBtn.textContent,
                         search_query: searchInput.dataset.savedValue || searchInput.value,
                         search_scopes: getSelectedScopes(),
                         show_selected_mode: showSelectedMode,
-                        min_rating: parseInt(minRatingSelect.value),
-                        max_rating: parseInt(maxRatingSelect.value),
+                        filter_ratings: Array.from(ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all):checked')).map(cb => parseInt(cb.value)),
                         recursive: recursiveMode,
+                        selection: selection,
                     };
                     setUiState.call(this, this.id, state);
+                    // Also save to node properties for clipspace (copy-paste)
+                    node_instance.setProperty("lmm_state", JSON.stringify(state));
                 };
 
                 const handleTagSelectionChange = () => {
-                    const selectedTags = Array.from(multiSelectTagDropdown.querySelectorAll('input:checked')).map(cb => cb.value);
+                    const checkboxes = multiSelectTagDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all)');
+                    const selectedTags = Array.from(checkboxes).filter(cb => cb.checked).map(cb => cb.value);
                     tagFilterInput.value = selectedTags.join(',');
                     lastFilteredTags = tagFilterInput.value.trim();
+                    const tagAllCb = multiSelectTagDropdown.querySelector('.lmm-select-all');
+                    if (tagAllCb) {
+                        const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+                        const noneChecked = Array.from(checkboxes).every(cb => !cb.checked);
+                        tagAllCb.checked = allChecked;
+                        tagAllCb.indeterminate = !allChecked && !noneChecked;
+                    }
                     saveStateAndReload(false);
                 };
 
@@ -2166,14 +2240,61 @@ app.registerExtension({
                 });
 
                 controls.querySelectorAll('select:not(.lmm-path-presets)').forEach(select => { select.addEventListener('change', () => saveStateAndReload(false)); });
-                showImagesCheckbox.addEventListener('change', () => saveStateAndReload(false));
-                showVideosCheckbox.addEventListener('change', () => saveStateAndReload(false));
-                showAudioCheckbox.addEventListener('change', () => saveStateAndReload(false));
-                minRatingSelect.addEventListener('change', () => saveStateAndReload(false));
-                maxRatingSelect.addEventListener('change', () => saveStateAndReload(false));
+                // Type icon click handlers are set up at DOM query time above
+                // Rating dropdown population and handlers
+                const ratingOptions = [
+                    { value: '0', label: '0★' },
+                    { value: '1', label: '1★' },
+                    { value: '2', label: '2★' },
+                    { value: '3', label: '3★' },
+                    { value: '4', label: '4★' },
+                    { value: '5', label: '5★' },
+                ];
+                const ratingAllCb = document.createElement('input');
+                ratingAllCb.type = 'checkbox';
+                ratingAllCb.className = 'lmm-select-all';
+                ratingAllCb.checked = true;
+                const handleRatingSelectionChange = () => {
+                    const checkboxes = ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all)');
+                    const selected = Array.from(checkboxes).filter(cb => cb.checked);
+                    const allChecked = selected.length === checkboxes.length;
+                    const noneChecked = selected.length === 0;
+                    ratingAllCb.checked = allChecked;
+                    ratingAllCb.indeterminate = !allChecked && !noneChecked;
+                    const checkedSet = new Set(selected.map(cb => cb.value));
+                    ratingDisplayText.textContent = ratingOptions.map(opt =>
+                        `${opt.value}${checkedSet.has(opt.value) ? '★' : '☆'}`
+                    ).join(' ');
+                    saveStateAndReload(false);
+                };
+                const ratingAllLabel = document.createElement('label');
+                ratingAllLabel.style.borderBottom = '1px solid #444';
+                ratingAllCb.addEventListener('change', () => {
+                    ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all)').forEach(cb => { cb.checked = ratingAllCb.checked; });
+                    handleRatingSelectionChange();
+                });
+                ratingAllLabel.appendChild(ratingAllCb);
+                ratingAllLabel.appendChild(document.createTextNode(' All'));
+                ratingDropdown.appendChild(ratingAllLabel);
+                ratingOptions.forEach(opt => {
+                    const label = document.createElement('label');
+                    const cb = document.createElement('input');
+                    cb.type = 'checkbox';
+                    cb.value = opt.value;
+                    cb.checked = true;
+                    cb.addEventListener('change', handleRatingSelectionChange);
+                    label.appendChild(cb);
+                    label.appendChild(document.createTextNode(` ${opt.label}`));
+                    ratingDropdown.appendChild(label);
+                });
+                ratingDisplay.addEventListener('click', () => {
+                    const isVisible = ratingDropdown.style.display === 'block';
+                    ratingDropdown.style.display = isVisible ? 'none' : 'block';
+                    ratingArrow.classList.toggle('open', !isVisible);
+                });
                 recursiveBtn.addEventListener('click', () => {
                     recursiveMode = !recursiveMode;
-                    recursiveBtn.classList.toggle('active', recursiveMode);
+                    recursiveBtn.classList.toggle('inactive', !recursiveMode);
                     saveStateAndReload(false);
                 });
                 let searchDebounceTimer = null;
@@ -2256,6 +2377,10 @@ app.registerExtension({
                     if (!multiSelectTagContainer.contains(e.target)) {
                         multiSelectTagDropdown.style.display = 'none';
                         arrow.classList.remove('open');
+                    }
+                    if (!ratingContainer.contains(e.target)) {
+                        ratingDropdown.style.display = 'none';
+                        ratingArrow.classList.remove('open');
                     }
                 });
 
@@ -2464,13 +2589,20 @@ app.registerExtension({
                     try {
                         const galleryId = this.properties.gallery_unique_id;
                         const response = await api.fetchApi(`/local_image_gallery/get_ui_state?node_id=${this.id}&gallery_id=${galleryId}`);
-                        const state = await response.json();
+                        let state = await response.json();
+                        // Clipspace fallback: if server returned defaults, try properties
+                        if (state && !state.last_path && node_instance.properties.lmm_state) {
+                            try {
+                                const propState = JSON.parse(node_instance.properties.lmm_state);
+                                state = { ...state, ...propState };
+                            } catch (e) {}
+                        }
                         if (state) {
                             controls.querySelector(".lmm-sort-by").value = state.sort_by;
                             controls.querySelector(".lmm-sort-order").value = state.sort_order;
-                            showImagesCheckbox.checked = state.show_images !== false;
-                            showVideosCheckbox.checked = state.show_videos;
-                            showAudioCheckbox.checked = state.show_audio;
+                            controls.querySelector('.lmm-type-icons span[data-type="images"]').classList.toggle('inactive', state.show_images === false);
+                            controls.querySelector('.lmm-type-icons span[data-type="videos"]').classList.toggle('inactive', !state.show_videos);
+                            controls.querySelector('.lmm-type-icons span[data-type="audio"]').classList.toggle('inactive', !state.show_audio);
                             tagFilterInput.value = state.filter_tag;
                             lastFilteredTags = (state.filter_tag || '').trim();
                             searchInput.value = state.search_query || '';
@@ -2480,10 +2612,15 @@ app.registerExtension({
                             savedScopes.forEach(s => activeScopes.add(s));
                             updateScopeDisplay();
                             showSelectedMode = state.show_selected_mode || false;
-                            if (state.min_rating !== undefined) minRatingSelect.value = state.min_rating;
-                            if (state.max_rating !== undefined) maxRatingSelect.value = state.max_rating;
+                            if (state.filter_ratings && state.filter_ratings.length > 0) {
+                                const selectedSet = new Set(state.filter_ratings);
+                                ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all)').forEach(cb => {
+                                    cb.checked = selectedSet.has(parseInt(cb.value));
+                                });
+                                handleRatingSelectionChange();
+                            }
                             recursiveMode = state.recursive || false;
-                            recursiveBtn.classList.toggle('active', recursiveMode);
+                            recursiveBtn.classList.toggle('inactive', !recursiveMode);
 
                             if (state.filter_mode) {
                                 tagFilterModeBtn.textContent = state.filter_mode;

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -609,6 +609,7 @@ app.registerExtension({
                         #${uniqueId} .lmm-tag-editor-list { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
                         #${uniqueId} .lmm-tag-editor-list .lmm-tag .lmm-remove-tag { margin-left: 4px; color: #fdd; cursor: pointer; font-weight: bold; }
                         #${uniqueId} .lmm-show-selected-btn.active { background-color: #4A90E2; color: white; border-color: #4A90E2; }
+                        #${uniqueId} .lmm-recursive-btn.active { background-color: #7C3AED; color: white; border-color: #7C3AED; }
                         #${uniqueId} .lmm-tag-filter-wrapper { display: flex; flex-grow: 1; position: relative; align-items: center; }
                         #${uniqueId} .lmm-tag-filter-wrapper input { flex-grow: 1; transition: box-shadow 0.2s; }
                         #${uniqueId} .lmm-multiselect-tag { position: relative; flex-grow: 1; }
@@ -730,10 +731,15 @@ app.registerExtension({
                         <div class="lmm-controls" style="gap: 5px;">
                             <label>Sort by:</label> <select class="lmm-sort-by"> <option value="name">Name</option> <option value="date">Date</option> <option value="rating">Rating</option> </select>
                             <label>Order:</label> <select class="lmm-sort-order"> <option value="asc">Ascending</option> <option value="desc">Descending</option> </select>
+                            <label>Rating:</label>
+                            <select class="lmm-min-rating"><option value="0">0</option><option value="1">1★</option><option value="2">2★</option><option value="3">3★</option><option value="4">4★</option><option value="5">5★</option></select>
+                            <span style="color: #888;">–</span>
+                            <select class="lmm-max-rating"><option value="0">0</option><option value="1">1★</option><option value="2">2★</option><option value="3">3★</option><option value="4">4★</option><option value="5" selected>5★</option></select>
                             <div style="margin-left: auto; display: flex; align-items: center; gap: 5px;">
                                 <label>Images:</label> <input type="checkbox" class="lmm-show-images" checked>
                                 <label>Videos:</label> <input type="checkbox" class="lmm-show-videos">
                                 <label>Audio:</label> <input type="checkbox" class="lmm-show-audio">
+                                <button class="lmm-recursive-btn" title="Show rated/tagged items from all subdirectories recursively">🔍 Recursive</button>
                                 <button class="lmm-show-selected-btn" title="Show all selected items across folders">Show Selected</button>
                                 <button class="lmm-batch-action-btn lmm-batch-select-all-btn" title="Select All Files in Current View">Select All</button>
                             </div>
@@ -778,6 +784,9 @@ app.registerExtension({
                 const multiSelectTagContainer = controls.querySelector(".lmm-multiselect-tag");
                 const multiSelectTagDisplay = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-display");
                 const multiSelectTagDropdown = multiSelectTagContainer.querySelector(".lmm-multiselect-tag-dropdown");
+                const minRatingSelect = controls.querySelector(".lmm-min-rating");
+                const maxRatingSelect = controls.querySelector(".lmm-max-rating");
+                const recursiveBtn = controls.querySelector(".lmm-recursive-btn");
                 const searchInput = controls.querySelector(".lmm-search-input");
                 const searchStatus = controls.querySelector(".lmm-search-status");
                 const searchScopeContainer = controls.querySelector(".lmm-search-scope-container");
@@ -1231,6 +1240,7 @@ app.registerExtension({
                 let isLoading = false, currentPage = 1, totalPages = 1, parentDir = null;
                 let selection = [];
                 let showSelectedMode = false;
+                let recursiveMode = false;
                 let lastKnownPath = "";
                 let selectedCardsForEditing = new Set();
 
@@ -1777,6 +1787,7 @@ app.registerExtension({
                     }
                     let url = `/local_image_gallery/images?directory=${encodeURIComponent(directory)}&page=${page}&sort_by=${sortBy}&sort_order=${sortOrder}&show_images=${showImages}&show_videos=${showVideos}&show_audio=${showAudio}&filter_tag=${encodeURIComponent(filterTag)}&search_mode=${searchMode}&filter_mode=${filterMode}&combine_mode=${combineMode}&force_refresh=${forceRefresh}&search_query=${encodeURIComponent(currentSearchQuery)}`;
                     currentSearchScopes.forEach(s => { url += `&search_scope=${encodeURIComponent(s)}`; });
+                    url += `&min_rating=${minRatingSelect.value}&max_rating=${maxRatingSelect.value}&recursive=${recursiveMode}`;
 
                     if (selection.length > 0) {
                         selection.forEach(item => { url += `&selected_paths=${encodeURIComponent(item.path)}`; });
@@ -2071,6 +2082,9 @@ app.registerExtension({
                         search_query: searchInput.dataset.savedValue || searchInput.value,
                         search_scopes: getSelectedScopes(),
                         show_selected_mode: showSelectedMode,
+                        min_rating: parseInt(minRatingSelect.value),
+                        max_rating: parseInt(maxRatingSelect.value),
+                        recursive: recursiveMode,
                     };
                     setUiState.call(this, this.id, state);
                 };
@@ -2155,6 +2169,13 @@ app.registerExtension({
                 showImagesCheckbox.addEventListener('change', () => saveStateAndReload(false));
                 showVideosCheckbox.addEventListener('change', () => saveStateAndReload(false));
                 showAudioCheckbox.addEventListener('change', () => saveStateAndReload(false));
+                minRatingSelect.addEventListener('change', () => saveStateAndReload(false));
+                maxRatingSelect.addEventListener('change', () => saveStateAndReload(false));
+                recursiveBtn.addEventListener('click', () => {
+                    recursiveMode = !recursiveMode;
+                    recursiveBtn.classList.toggle('active', recursiveMode);
+                    saveStateAndReload(false);
+                });
                 let searchDebounceTimer = null;
                 let lastSearchedQuery = '';
 
@@ -2459,6 +2480,10 @@ app.registerExtension({
                             savedScopes.forEach(s => activeScopes.add(s));
                             updateScopeDisplay();
                             showSelectedMode = state.show_selected_mode || false;
+                            if (state.min_rating !== undefined) minRatingSelect.value = state.min_rating;
+                            if (state.max_rating !== undefined) maxRatingSelect.value = state.max_rating;
+                            recursiveMode = state.recursive || false;
+                            recursiveBtn.classList.toggle('active', recursiveMode);
 
                             if (state.filter_mode) {
                                 tagFilterModeBtn.textContent = state.filter_mode;
@@ -2470,6 +2495,15 @@ app.registerExtension({
                             }
 
                             selection = state.selection || [];
+                            // Fallback: if UI state has no selection, try properties (copy-paste scenario)
+                            if (selection.length === 0) {
+                                try {
+                                    const propSel = JSON.parse(node_instance.properties.selection || "[]");
+                                    if (Array.isArray(propSel) && propSel.length > 0) {
+                                        selection = propSel;
+                                    }
+                                } catch (e) {}
+                            }
                             updateBatchActionButtonsState();
 
                             const selectionJson = JSON.stringify(selection);

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -1537,7 +1537,21 @@ app.registerExtension({
                     const d = new Date(item.mtime * 1000);
                     const pad = (n) => String(n).padStart(2, '0');
                     const mtimeStr = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-                    card.title = `Name: ${item.name}\nPath: ${dir}\nType: ${item.type}\nLast Edited: ${mtimeStr}`;
+                    let tooltip = `Name: ${item.name}\nPath: ${dir}\nType: ${item.type}\nLast Edited: ${mtimeStr}`;
+                    if (item.media_info) {
+                        const mi = item.media_info;
+                        if (mi.width && mi.height) tooltip += `\nDimensions: ${mi.width}x${mi.height}`;
+                        if (mi.fps) tooltip += `\nFPS: ${mi.fps}`;
+                        if (mi.total_frames) tooltip += `\nFrames: ${mi.total_frames}`;
+                        if (mi.duration != null) {
+                            const s = Math.round(mi.duration);
+                            const h = Math.floor(s / 3600);
+                            const m = Math.floor((s % 3600) / 60);
+                            const sec = s % 60;
+                            tooltip += `\nDuration: ${h > 0 ? `${h}:${String(m).padStart(2,'0')}` : String(m)}:${String(sec).padStart(2,'0')}`;
+                        }
+                    }
+                    card.title = tooltip;
 
                     let mediaHTML = "";
                     if (item.type === 'dir') {

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -162,6 +162,8 @@ function setupGlobalMaskEditor() {
         .lmm-mask-editor-actions { margin-top: 10px; display: flex; justify-content: flex-end; gap: 10px; }
         .lmm-mask-editor-btn-primary { background: #236694; color: white; border: none; padding: 5px 15px; border-radius: 4px; cursor: pointer; }
         .lmm-mask-editor-btn-secondary { background: #444; color: white; border: none; padding: 5px 15px; border-radius: 4px; cursor: pointer; }
+        .lmm-mask-editor-btn-danger { background: #8B2020; color: white; border: none; padding: 5px 15px; border-radius: 4px; cursor: pointer; display: none; }
+        .lmm-mask-editor-btn-danger:hover { background: #B22222; }
         .lmm-brush-cursor {
             position: absolute; border: 1px solid rgba(255, 255, 255, 0.9); box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.8); border-radius: 50%; pointer-events: none; z-index: 10003; transform: translate(-50%, -50%); display: none;
         }
@@ -201,6 +203,7 @@ function setupGlobalMaskEditor() {
                 
                 <div class="lmm-mask-editor-actions" style="flex-shrink:0;">
                     <div id="lmm-mask-info" style="position: absolute; bottom: 14px; left: 10px; color: #eee; background: rgba(0, 0, 0, 0.6); padding: 4px 8px; border-radius: 4px; font-size: 14px; pointer-events: none; user-select: none; z-index: 10002; font-family: monospace;">0 x 0 | 100%</div>
+                    <button id="lmm-mask-delete" class="lmm-mask-editor-btn-danger">Delete Mask</button>
                     <button id="lmm-mask-cancel" class="lmm-mask-editor-btn-secondary">Cancel</button>
                     <button id="lmm-mask-save" class="lmm-mask-editor-btn-primary">Save Mask</button>
                 </div>
@@ -316,6 +319,19 @@ function setupGlobalMaskEditor() {
         } catch (e) { alert("Failed: " + e); } finally { btn.textContent = "Save Mask"; btn.disabled = false; }
     };
 
+    const deleteBtn = document.getElementById("lmm-mask-delete");
+    deleteBtn.onclick = async () => {
+        if (!confirm("Permanently delete this mask sidecar file?")) return;
+        deleteBtn.textContent = "Deleting..."; deleteBtn.disabled = true;
+        try {
+            await api.fetchApi("/local_image_gallery/delete_mask", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ image_path: currentImagePath }) });
+            maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
+            deleteBtn.style.display = "none";
+            if (lmm_mask_on_save_callback) lmm_mask_on_save_callback();
+            overlay.style.display = "none";
+        } catch (e) { alert("Failed to delete mask: " + e); } finally { deleteBtn.textContent = "Delete Mask"; deleteBtn.disabled = false; }
+    };
+
     document.getElementById("lmm-mask-clear").onclick = async () => {
         maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
     };
@@ -380,6 +396,7 @@ function setupGlobalMaskEditor() {
 
                 maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
 
+                deleteBtn.style.display = (data.status === 'ok' && data.mask_path) ? 'inline-block' : 'none';
                 if (data.status === 'ok' && data.mask_path) {
                     const mImg = new Image();
                     mImg.onload = () => {
@@ -572,6 +589,7 @@ app.registerExtension({
                             display: flex;
                             justify-content: space-between;
                             align-items: center;
+                            gap: 4px;
                             width: 100%;
                             margin-bottom: 4px;
                         }
@@ -589,12 +607,46 @@ app.registerExtension({
                         #${uniqueId} .lmm-workflow-text-badge:hover {
                             background-color: rgba(80,80,80,0.6);
                         }
-                        
-                        #${uniqueId} .edit-tags-btn, #${uniqueId} .open-media-btn, #${uniqueId} .copy-path-btn { position: absolute; bottom: 2px; width: 22px; height: 22px; background-color: rgba(0,0,0,0.5); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; transition: background-color 0.2s; opacity: 0; cursor: pointer; }
-                        #${uniqueId} .open-media-btn { right: 2px; }
-                        #${uniqueId} .edit-tags-btn { right: 28px; }
-                        #${uniqueId} .copy-path-btn { right: 54px; }
-                        #${uniqueId} .lmm-gallery-card:hover .edit-tags-btn, #${uniqueId} .lmm-gallery-card:hover .open-media-btn, #${uniqueId} .lmm-gallery-card:hover .copy-path-btn { opacity: 1; }
+                        #${uniqueId} .lmm-mask-badge {
+                            font-size: 10px;
+                            font-weight: bold;
+                            color: #B0E0FF;
+                            background-color: rgba(0,0,0,0.4);
+                            padding: 2px 5px;
+                            border-radius: 4px;
+                            cursor: pointer;
+                            transition: background-color 0.2s;
+                        }
+                        #${uniqueId} .lmm-mask-badge:hover {
+                            background-color: rgba(80,80,80,0.6);
+                        }
+                        #${uniqueId} img.lmm-mask-overlay {
+                            position: absolute;
+                            top: 0; left: 0; width: 100%; height: 100%;
+                            opacity: 0;
+                            transition: opacity 0.2s;
+                            pointer-events: none;
+                            object-fit: cover;
+                            border-radius: 0;
+                        }
+                        #${uniqueId} .lmm-card-media-wrapper:hover .lmm-mask-overlay.loaded {
+                            opacity: 0.75;
+                        }
+                        #${uniqueId} .lmm-mask-filter-toggle {
+                            cursor: pointer;
+                            user-select: none;
+                            font-size: 14px;
+                            line-height: 1;
+                            transition: opacity 0.15s;
+                        }
+                        #${uniqueId} .lmm-mask-filter-toggle.inactive { opacity: 0.2; }
+                        #${uniqueId} .lmm-mask-filter-toggle.no-mask {
+                            filter: drop-shadow(0 0 4px #ff4444) drop-shadow(0 0 8px #ff2222);
+                        }
+
+                        #${uniqueId} .lmm-card-actions { display: flex; align-items: center; gap: 4px; width: 100%; }
+                        #${uniqueId} .lmm-card-actions-right { display: flex; gap: 2px; margin-left: auto; }
+                        #${uniqueId} .edit-tags-btn, #${uniqueId} .open-media-btn, #${uniqueId} .copy-path-btn { width: 22px; height: 22px; background-color: rgba(0,0,0,0.3); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; transition: background-color 0.2s; cursor: pointer; }
                         #${uniqueId} .edit-tags-btn:hover, #${uniqueId} .open-media-btn:hover, #${uniqueId} .copy-path-btn:hover { background-color: rgba(0,0,0,0.8); }
                         #${uniqueId} .lmm-star-rating { font-size: 16px; cursor: pointer; color: #555; }
                         #${uniqueId} .lmm-star-rating .lmm-star:hover { color: #FFD700 !important; }
@@ -756,6 +808,7 @@ app.registerExtension({
                                 </div>
                                 <div class="lmm-multiselect-rating-dropdown"></div>
                             </div>
+                            <span class="lmm-mask-filter-toggle inactive" title="No mask filter active. Click to cycle: mask only → no mask → off">🎭</span>
                             <div style="margin-left: auto; display: flex; align-items: center; gap: 5px;">
                                 <span class="lmm-type-icons"><span data-type="images" title="Show images">🖼️</span><span data-type="videos" title="Show videos">🎬</span><span data-type="audio" class="inactive" title="Show audio">🔊</span></span>
                                 <button class="lmm-recursive-btn inactive" title="Show items from all subdirectories recursively">📂 Recursive</button>
@@ -814,6 +867,8 @@ app.registerExtension({
                 const ratingDisplayText = ratingContainer.querySelector(".lmm-rating-display-text");
                 const ratingArrow = ratingContainer.querySelector(".lmm-multiselect-arrow");
                 const recursiveBtn = controls.querySelector(".lmm-recursive-btn");
+                const maskFilterToggle = controls.querySelector(".lmm-mask-filter-toggle");
+                let maskFilterState = ''; // '' = off, 'mask_only', 'no_mask'
                 const searchInput = controls.querySelector(".lmm-search-input");
                 const searchStatus = controls.querySelector(".lmm-search-status");
                 const searchScopeContainer = controls.querySelector(".lmm-search-scope-container");
@@ -1600,6 +1655,7 @@ app.registerExtension({
                             tooltip += `\nDuration: ${h > 0 ? `${h}:${String(m).padStart(2,'0')}` : String(m)}:${String(sec).padStart(2,'0')}`;
                         }
                     }
+                    if (item.has_mask) tooltip += `\nMask: yes`;
                     card.title = tooltip;
 
                     let mediaHTML = "";
@@ -1614,6 +1670,25 @@ app.registerExtension({
                     }
                     card.innerHTML = mediaHTML;
 
+                    if (item.mask_path) {
+                        const wrapper = card.querySelector('.lmm-card-media-wrapper');
+                        if (wrapper) {
+                            const maskImg = document.createElement('img');
+                            maskImg.className = 'lmm-mask-overlay';
+                            maskImg.loading = 'lazy';
+                            maskImg.alt = 'mask';
+                            // Defer src until first hover to avoid loading all masks upfront
+                            const maskSrc = `/local_image_gallery/view?filepath=${encodeURIComponent(item.mask_path)}`;
+                            wrapper.addEventListener('mouseenter', () => {
+                                if (!maskImg.src) {
+                                    maskImg.src = maskSrc;
+                                    maskImg.onload = () => maskImg.classList.add('loaded');
+                                }
+                            }, { once: true });
+                            wrapper.appendChild(maskImg);
+                        }
+                    }
+
                     if (item.type === 'image' || item.type === 'video') {
                         const infoPanel = document.createElement("div");
                         infoPanel.className = 'lmm-card-info-panel';
@@ -1621,16 +1696,22 @@ app.registerExtension({
                         const tags = item.tags.map(t => `<span class="lmm-tag" title="Click to filter by this tag">${t}</span>`).join('');
 
                         const workflowTextBadge = item.has_workflow ? `<div class="lmm-workflow-text-badge" title="Click to load workflow">Workflow</div>` : '';
+                        const maskBadge = item.has_mask ? `<div class="lmm-mask-badge" title="Click to open mask editor">🎭 Mask</div>` : '';
 
                         infoPanel.innerHTML = `
                             <div class="lmm-info-top-row">
                                 <div class="lmm-star-rating">${stars}</div>
                                 ${workflowTextBadge}
                             </div>
+                            <div class="lmm-card-actions">
+                                ${maskBadge}
+                                <div class="lmm-card-actions-right">
+                                    <div class="copy-path-btn" title="Copy file path">📁</div>
+                                    <div class="edit-tags-btn" title="Edit tags">✏️</div>
+                                    <div class="open-media-btn" title="Open in lightbox">🔎</div>
+                                </div>
+                            </div>
                             <div class="lmm-tag-list">${tags}</div>
-                            <div class="copy-path-btn" title="Copy file path">📁</div>
-                            <div class="open-media-btn" title="Open in lightbox">🔎</div>
-                            <div class="edit-tags-btn" title="Edit tags">✏️</div>
                         `;
                         card.appendChild(infoPanel);
 
@@ -1662,6 +1743,21 @@ app.registerExtension({
                                         alert("Failed to load workflow from media. See console for details.");
                                         workflowTextEl.style.backgroundColor = '#F44336';
                                         workflowTextEl.textContent = "Failed!";
+                                    }
+                                });
+                            }
+                        }
+
+                        if (item.has_mask && item.type === 'image') {
+                            const maskBadgeEl = card.querySelector(".lmm-mask-badge");
+                            if (maskBadgeEl) {
+                                maskBadgeEl.addEventListener("click", (e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    if (window.lmmOpenMaskEditor) {
+                                        window.lmmOpenMaskEditor(item.path, () => {
+                                            saveStateAndReload(true);
+                                        });
                                     }
                                 });
                             }
@@ -1850,7 +1946,7 @@ app.registerExtension({
                     let url = `/local_image_gallery/images?directory=${encodeURIComponent(directory)}&page=${page}&sort_by=${sortBy}&sort_order=${sortOrder}&show_images=${showImages}&show_videos=${showVideos}&show_audio=${showAudio}&filter_tag=${encodeURIComponent(filterTag)}&search_mode=${searchMode}&filter_mode=${filterMode}&combine_mode=${combineMode}&force_refresh=${forceRefresh}&search_query=${encodeURIComponent(currentSearchQuery)}`;
                     currentSearchScopes.forEach(s => { url += `&search_scope=${encodeURIComponent(s)}`; });
                     const selectedRatings = Array.from(ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all):checked')).map(cb => cb.value);
-                    url += `&filter_ratings=${selectedRatings.join(',')}&recursive=${recursiveMode}`;
+                    url += `&filter_ratings=${selectedRatings.join(',')}&recursive=${recursiveMode}&mask_filter=${maskFilterState}`;
 
                     if (selection.length > 0) {
                         selection.forEach(item => { url += `&selected_paths=${encodeURIComponent(item.path)}`; });
@@ -2161,6 +2257,7 @@ app.registerExtension({
                         search_scopes: getSelectedScopes(),
                         show_selected_mode: showSelectedMode,
                         filter_ratings: Array.from(ratingDropdown.querySelectorAll('input[type="checkbox"]:not(.lmm-select-all):checked')).map(cb => parseInt(cb.value)),
+                        mask_filter: maskFilterState,
                         recursive: recursiveMode,
                         selection: selection,
                     };
@@ -2312,6 +2409,25 @@ app.registerExtension({
                 recursiveBtn.addEventListener('click', () => {
                     recursiveMode = !recursiveMode;
                     recursiveBtn.classList.toggle('inactive', !recursiveMode);
+                    saveStateAndReload(false);
+                });
+                const updateMaskFilterDisplay = () => {
+                    maskFilterToggle.classList.remove('inactive', 'no-mask');
+                    if (maskFilterState === '') {
+                        maskFilterToggle.classList.add('inactive');
+                        maskFilterToggle.title = 'No mask filter active. Click to cycle: mask only → no mask → off';
+                    } else if (maskFilterState === 'mask_only') {
+                        maskFilterToggle.title = 'Showing items with masks only. Click to cycle: no mask → off';
+                    } else if (maskFilterState === 'no_mask') {
+                        maskFilterToggle.classList.add('no-mask');
+                        maskFilterToggle.title = 'Showing items without masks only. Click to cycle: off';
+                    }
+                };
+                maskFilterToggle.addEventListener('click', () => {
+                    if (maskFilterState === '') maskFilterState = 'mask_only';
+                    else if (maskFilterState === 'mask_only') maskFilterState = 'no_mask';
+                    else maskFilterState = '';
+                    updateMaskFilterDisplay();
                     saveStateAndReload(false);
                 });
                 let searchDebounceTimer = null;
@@ -2637,6 +2753,8 @@ app.registerExtension({
                             }
                             recursiveMode = state.recursive || false;
                             recursiveBtn.classList.toggle('inactive', !recursiveMode);
+                            maskFilterState = state.mask_filter || '';
+                            updateMaskFilterDisplay();
 
                             if (state.filter_mode) {
                                 tagFilterModeBtn.textContent = state.filter_mode;

--- a/js/Local_Media_Manager.js
+++ b/js/Local_Media_Manager.js
@@ -2669,6 +2669,8 @@ app.registerExtension({
                                 lastKnownPath = state.last_path;
                             }
 
+                            // Persist state to properties so subsequent copies carry it
+                            saveCurrentControlsState();
                             switchToBreadcrumb(false);
                             resetAndReload(false);
                         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 send2trash
 opencv-python-headless
 torchaudio
+av>=12.0  # >=12 bundles FFmpeg with libdav1d for AV1 software decode


### PR DESCRIPTION
Adds filename search to the gallery node. You can search for files by name across any combination of directories, with wildcard and fuzzy matching support, backed by a two-level cache.

<img width="1368" height="483" alt="Screenshot_20260207_094620" src="https://github.com/user-attachments/assets/0147267d-2087-40b1-b961-d4107602d783" />

## Search

New search row between the breadcrumb bar and sort controls:

<!-- screenshot: search bar with scope icons showing a search query and results -->

Type a query into the search input to find files by name. The search triggers on Enter, on blur, or automatically after 1 second of inactivity. Escape clears the field.

An ❓ icon appears in the search input when empty. Clicking it opens a search guide dialog explaining the matching tiers and scope controls. The dialog anchors to the icon, follows graph panning, and dismisses on click-outside, Escape, or the ✕ button.

Scope icons next to the input control which directories are searched:

| Icon | Scope |
|------|-------|
| 📂 | Current directory (recursive) |
| 📥 | ComfyUI `input/` directory |
| 📤 | ComfyUI `output/` directory |
| 💾 | All saved paths from the path presets |
| 🌐 | Toggle all scopes at once |

Each icon toggles independently. Hover shows a tooltip with details (current path, list of saved paths, etc). Overlapping scopes are deduplicated via `realpath` so the same file never appears twice. When all scopes are off, the search input disables with a hint.

<!-- screenshot: scope icon tooltip showing saved paths list -->

A status banner shows what's active — e.g. `🔍 Searching media with "sunset" (fuzzy) and tags: [landscape] in input/ & output/`.

Clicking the breadcrumb during an active search cancels it and returns to the last browsed directory.

The scope icons apply to both filename search and tag-only filtering. Previously, the "Global Search" checkbox toggled tag search between current-directory-only and all-metadata. Now the scope icons control exactly which directories are included — tag-only searches filter metadata paths against the selected scope roots using `realpath` normalization.

## How queries are matched

The query is lowercased and matched against each filename and directory name (also lowercased). Matching works in three tiers, tried in order:

**1. Substring** (default) — `query in filename`. The query `sun` matches `sunset_beach.png`, `sunrise.jpg`, `My_Sunsetter_v2.mp4`.

**2. Wildcard** — activated when the query contains `*` or `?`. Uses Python's `fnmatch` (shell glob rules). `*.png` matches all PNGs. `photo_??.jpg` matches `photo_01.jpg` but not `photo_1.jpg` or `photo_001.jpg`.

**3. Fuzzy** (automatic fallback) — if substring matching returns zero results AND the query has no wildcards, Levenshtein distance matching runs automatically. It compares the query against the filename **stem** (extension stripped), with an adaptive threshold:
  - Queries of 1-2 characters: fuzzy is skipped entirely (too short for meaningful edit distance)
  - Queries of 3-5 characters: allows 1 edit (insert, delete, or substitute)
  - Queries of 6+ characters: allows 2 edits

  For example, `sunet` (5 chars, threshold 1) matches `sunset` (1 substitution). `bech_photo` (10 chars, threshold 2) matches `beach_photo` (1 insertion). When fuzzy matching is used, the status bar shows "(fuzzy)".

Wildcard queries never fall back to fuzzy — if `*.tif` matches nothing, it returns empty, since the user expressed an exact pattern intent.

Tag filtering (the existing tag field) applies as a post-filter on top of filename search results, so you can combine both: search for filename `sunset` filtered to tag `landscape`.

## Caching

**Backend** — new `DirCache` class replaces the old in-memory `DIRECTORY_CACHE` dict:
- L1 memory + L2 disk (`.cache/dirscan/`, MD5-hashed keys), both with 30-minute TTL
- Per-key `asyncio.Lock` coalesces concurrent requests — if 3 nodes request the same directory simultaneously, only one scan runs
- Scans run on a thread pool (`run_in_executor`) so the aiohttp event loop isn't blocked
- Metadata reads are mtime-gated: `load_metadata()` only re-reads the JSON file when its mtime changes

**Frontend** — module-level promise cache (2s TTL) for `get_all_tags` and `get_saved_paths`. Multiple LMM nodes on the canvas share a single in-flight request instead of each firing their own. Cache is invalidated when tags or paths are mutated.

## Other changes
- Tag filter input now triggers on debounce (1s) and blur, not just Enter. Escape clears it.
- Whitespace normalized across both files — `.git-blame-ignore-revs` added so `git blame` skips the formatting commit
- Removed unused imports (`ImageOps`, `torchaudio`)
- Added `.gitignore` for runtime files